### PR TITLE
Uses a more specific regex to match CPE & PURL during udpates

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -18,6 +18,8 @@ docker_credentials:
 
 dependencies:
 - id:   open-liberty-runtime-full
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
   with:
     uri:         https://repo1.maven.org/maven2
@@ -25,6 +27,8 @@ dependencies:
     artifact_id: openliberty-runtime
     packaging:   zip
 - id:   open-liberty-runtime-jakartaee9
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
   with:
     uri:         https://repo1.maven.org/maven2
@@ -32,6 +36,8 @@ dependencies:
     artifact_id: openliberty-jakartaee9
     packaging:   zip
 - id:   open-liberty-runtime-javaee8
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
   with:
     uri:         https://repo1.maven.org/maven2
@@ -39,6 +45,8 @@ dependencies:
     artifact_id: openliberty-javaee8
     packaging:   zip
 - id:   open-liberty-runtime-webProfile9
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
   with:
     uri:         https://repo1.maven.org/maven2
@@ -46,6 +54,8 @@ dependencies:
     artifact_id: openliberty-webProfile9
     packaging:   zip
 - id:   open-liberty-runtime-webProfile8
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
   with:
     uri:         https://repo1.maven.org/maven2
@@ -53,6 +63,8 @@ dependencies:
     artifact_id: openliberty-webProfile8
     packaging:   zip
 - id:   open-liberty-runtime-microProfile5
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
   with:
     uri:         https://repo1.maven.org/maven2
@@ -60,6 +72,8 @@ dependencies:
     artifact_id: openliberty-microProfile5
     packaging:   zip
 - id:   open-liberty-runtime-microProfile4
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
   with:
     uri:         https://repo1.maven.org/maven2
@@ -67,6 +81,8 @@ dependencies:
     artifact_id: openliberty-microProfile4
     packaging:   zip
 - id:   open-liberty-runtime-microProfile3
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
   with:
     uri:         https://repo1.maven.org/maven2
@@ -74,6 +90,8 @@ dependencies:
     artifact_id: openliberty-microProfile3
     packaging:   zip
 - id:   open-liberty-runtime-kernel
+  purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
+  cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
   with:
     uri:         https://repo1.maven.org/maven2

--- a/.github/workflows/update-open-liberty-runtime-full.yml
+++ b/.github/workflows/update-open-liberty-runtime-full.yml
@@ -89,10 +89,10 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-full
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}

--- a/.github/workflows/update-open-liberty-runtime-jakartaee-9.yml
+++ b/.github/workflows/update-open-liberty-runtime-jakartaee-9.yml
@@ -89,10 +89,10 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-jakartaee9
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}

--- a/.github/workflows/update-open-liberty-runtime-javaee-8.yml
+++ b/.github/workflows/update-open-liberty-runtime-javaee-8.yml
@@ -89,10 +89,10 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-javaee8
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}

--- a/.github/workflows/update-open-liberty-runtime-kernel.yml
+++ b/.github/workflows/update-open-liberty-runtime-kernel.yml
@@ -89,10 +89,10 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-kernel
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}

--- a/.github/workflows/update-open-liberty-runtime-micro-profile-3.yml
+++ b/.github/workflows/update-open-liberty-runtime-micro-profile-3.yml
@@ -89,10 +89,10 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-microProfile3
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}

--- a/.github/workflows/update-open-liberty-runtime-micro-profile-4.yml
+++ b/.github/workflows/update-open-liberty-runtime-micro-profile-4.yml
@@ -89,10 +89,10 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-microProfile4
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}

--- a/.github/workflows/update-open-liberty-runtime-micro-profile-5.yml
+++ b/.github/workflows/update-open-liberty-runtime-micro-profile-5.yml
@@ -89,10 +89,10 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-microProfile5
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}

--- a/.github/workflows/update-open-liberty-runtime-web-profile-8.yml
+++ b/.github/workflows/update-open-liberty-runtime-web-profile-8.yml
@@ -89,10 +89,10 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-webProfile8
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}

--- a/.github/workflows/update-open-liberty-runtime-web-profile-9.yml
+++ b/.github/workflows/update-open-liberty-runtime-web-profile-9.yml
@@ -89,10 +89,10 @@ jobs:
                 echo "::set-output name=version-label::${LABEL}"
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
-                CPE_PATTERN: ""
+                CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-webProfile9
                 PURL: ${{ steps.dependency.outputs.purl }}
-                PURL_PATTERN: ""
+                PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}


### PR DESCRIPTION
## Summary

Prior to this PR, we are [getting spurious PRs](https://github.com/paketo-buildpacks/liberty/pull/92) that incorrectly change the version in the CPE & PURL. The reason is that the default regex for updating the CPE & PURL is the version regex, which matches three dot-separated digits. The version numbers in the CPE & PURL are four dot separate digits, so the default regex matches the first three digits and updates just that part, which results in a bad PR.

This switches the CPE & PURL to using four dot separate digits as the version regex. This should match the full version number and cause it to update correctly.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
