### PR TITLE
Server should listen on all interfaces.

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -28,7 +28,7 @@ api = "0.7"
     uri = "https://github.com/paketo-buildpacks/liberty/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/main", "bin/helper", "buildpack.toml", "templates/app.tmpl", "templates/features.tmpl"]
+  include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/main", "bin/helper", "buildpack.toml", "templates/app.tmpl", "templates/features.tmpl", "templates/default-http-endpoint.tmpl"]
   pre-package = "scripts/build.sh"
 
   [[metadata.configurations]]

--- a/helper/linker_test.go
+++ b/helper/linker_test.go
@@ -84,6 +84,7 @@ func testLink(t *testing.T, context spec.G, it spec.S) {
 			templatesDir := filepath.Join(baseLayerDir, "templates")
 			Expect(os.MkdirAll(templatesDir, 0755)).To(Succeed())
 			Expect(ioutil.WriteFile(filepath.Join(templatesDir, "app.tmpl"), []byte{}, 0644)).To(Succeed())
+			Expect(ioutil.WriteFile(filepath.Join(templatesDir, "default-http-endpoint.tmpl"), []byte{}, 0644)).To(Succeed())
 		})
 
 		it.After(func() {
@@ -110,6 +111,9 @@ func testLink(t *testing.T, context spec.G, it spec.S) {
 
 			appConfigPath := filepath.Join(layerDir, "usr", "servers", "defaultServer", "configDropins", "overrides", "app.xml")
 			Expect(appConfigPath).To(BeARegularFile())
+
+			httpEndpointConfigPath := filepath.Join(layerDir, "usr", "servers", "defaultServer", "configDropins", "defaults", "default-http-endpoint.xml")
+			Expect(httpEndpointConfigPath).To(BeARegularFile())
 		})
 	})
 

--- a/templates/default-http-endpoint.tmpl
+++ b/templates/default-http-endpoint.tmpl
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<server>
+    <httpEndpoint id="defaultHttpEndpoint" host="*" httpPort="9080" httpsPort="9443" />
+</server>


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Fixes an issue where Liberty server is not accessible outside of the
container since server by default listens on localhost only.

Fixes #69.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
