### PR TITLE
Implements RFC 0008 & `BP_JAVA_APP_SERVER` for Liberty

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The buildpack will participate when building any of the following:
 
 When building a web application, this buildpack will participate if all the following conditions are met:
 
+* `$BP_JAVA_APP_SERVER` is `liberty` or if `$BP_JAVA_APP_SERVER` is unset or empty and this is the first buildpack to provide a Java application server.
 * `Main-Class` is NOT defined in the manifest
 * `<APPLICATION_ROOT>/META-INF/application.xml` or `<APPLICATION_ROOT>/WEB-INF` exist
 
@@ -37,17 +38,18 @@ The buildpack will support all available profiles of the most recent versions of
 ## Configuration
 
 | Environment Variable           | Description                                                                                                                                                                                                                                                         |
-|--------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `$BP_JAVA_APP_SERVER`          | The application server to use. It defaults to `` (empty string) which means that order dictates which Java application server is installed. The first Java application server buildpack to run will be picked.                                                      |
 | `$BP_LIBERTY_INSTALL_TYPE`     | [Install type](#install-types) of Liberty. Valid options: `ol` and `none`. Defaults to `ol`.                                                                                                                                                                        |
 | `$BP_LIBERTY_VERSION`          | The version of Liberty to install. Defaults to the latest version of the runtime.                                                                                                                                                                                   |
 | `$BP_LIBERTY_PROFILE`          | The Liberty profile to use. Defaults to `full`.                                                                                                                                                                                                                     |
 | `$BP_LIBERTY_SERVER_NAME`      | Name of the server to use. Defaults to `defaultServer` when building an application. If building a packaged server and there is only one bundled server present, then the buildpack will use that.                                                                  |
 | `$BP_LIBERTY_CONTEXT_ROOT`     | If the [server.xml](#bindings) does not have an [application](https://openliberty.io/docs/latest/reference/config/application.html) named `app` defined, then the buildpack will generate one and use this value as the context root. Defaults to the value of `/`. |
-| `$BPL_LIBERTY_LOG_LEVEL`       | Sets the [logging](https://openliberty.io/docs/21.0.0.11/log-trace-configuration.html#configuaration) level. If not set, attempts to get the buildpack's log level. If unable, defaults to `INFO`                                                                   |
 | `$BP_LIBERTY_EXT_CONF_SHA256`  | The SHA256 hash of the external configuration package.                                                                                                                                                                                                              |
 | `$BP_LIBERTY_EXT_CONF_STRIP`   | The number of directory levels to strip from the external configuration package. Defaults to 0.                                                                                                                                                                     |
 | `$BP_LIBERTY_EXT_CONF_URI`     | The download URI of the external configuration package.                                                                                                                                                                                                             |
 | `$BP_LIBERTY_EXT_CONF_VERSION` | The version of the external configuration package.                                                                                                                                                                                                                  |
+| `$BPL_LIBERTY_LOG_LEVEL`       | Sets the [logging](https://openliberty.io/docs/21.0.0.11/log-trace-configuration.html#configuaration) level. If not set, attempts to get the buildpack's log level. If unable, defaults to `INFO`                                                                   |
 
 ### Default Configurations that Vary from Open Liberty's Default
 
@@ -69,14 +71,14 @@ The buildpack accepts the following bindings:
 ### Type: `liberty`
 
 | Key                    | Value             | Description                                                                                                                                                                   |
-|------------------------|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ---------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `server.xml`           | `<file-contents>` | This file will replace the `defaultServer`'s `server.xml` and is not subject to any post-processing; therefore, any variable references therein must be resolvable. Optional. |
 | `bootstrap.properties` | `<file-contents>` | This file will replace the `defaultServer`'s `bootstrap.properties`. This is one place to define variables used by `server.xml`. Optional.                                    |
 
 ### Type: `dependency-mapping`
 
 | Key                   | Value   | Description                                                                                       |
-|-----------------------|---------|---------------------------------------------------------------------------------------------------|
+| --------------------- | ------- | ------------------------------------------------------------------------------------------------- |
 | `<dependency-digest>` | `<uri>` | If needed, the buildpack will fetch the dependency with digest `<dependency-digest>` from `<uri>` |
 
 ## Using Custom Features

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -33,6 +33,12 @@ api = "0.7"
 
   [[metadata.configurations]]
     build = true
+    description = "the application server to use"
+    default = ""
+    name = "BP_JAVA_APP_SERVER"
+
+  [[metadata.configurations]]
+    build = true
     default = "ol"
     description = "Install type of Liberty"
     launch = false

--- a/helper/linker_test.go
+++ b/helper/linker_test.go
@@ -69,13 +69,22 @@ func testLink(t *testing.T, context spec.G, it spec.S) {
 		Expect(err).To(MatchError("$BPI_LIBERTY_RUNTIME_ROOT must be set"))
 	})
 
-	it("fails as BPI_LIBERTY_SERVER_NAME is required", func() {
-		Expect("/workspace").NotTo(BeADirectory())
-		Expect("/layers/paketo-buildpacks_liberty/open-liberty-runtime").NotTo(BeADirectory())
-		Expect(os.Setenv("BPI_LIBERTY_RUNTIME_ROOT", layerDir)).To(Succeed())
+	context("with BPI_LIBERTY_RUNTIME_ROOT set", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BPI_LIBERTY_RUNTIME_ROOT", layerDir)).To(Succeed())
+		})
 
-		_, err := linker.Execute()
-		Expect(err).To(MatchError("unable to configure\n$BPI_LIBERTY_SERVER_NAME must be set"))
+		it.After(func() {
+			Expect(os.Unsetenv("BPI_LIBERTY_RUNTIME_ROOT")).To(Succeed())
+		})
+
+		it("still fails as BPI_LIBERTY_SERVER_NAME is required", func() {
+			Expect("/workspace").NotTo(BeADirectory())
+			Expect("/layers/paketo-buildpacks_liberty/open-liberty-runtime").NotTo(BeADirectory())
+
+			_, err := linker.Execute()
+			Expect(err).To(MatchError("unable to configure\n$BPI_LIBERTY_SERVER_NAME must be set"))
+		})
 	})
 
 	context("with explicit env vars set to valid dirs", func() {

--- a/internal/core/buildsrc.go
+++ b/internal/core/buildsrc.go
@@ -63,6 +63,7 @@ func (a AppBuildSource) Name() string {
 
 // Detect checks to make sure Main-Class is not defined in `META-INF/MANIFEST.MF`
 func (a AppBuildSource) Detect() (bool, error) {
+        // if user reqeuests an app server and it's not liberty then skip
 	if a.RequestedAppServer != "" && a.RequestedAppServer != JavaAppServerLiberty {
 		a.Logger.Debugf("failed to match requested app server of [%s], buildpack supports [%s]", a.RequestedAppServer, JavaAppServerLiberty)
 		return false, nil

--- a/internal/core/buildsrc_test.go
+++ b/internal/core/buildsrc_test.go
@@ -13,17 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package core_test
 
 import (
-	"github.com/paketo-buildpacks/liberty/internal/core"
-	"github.com/paketo-buildpacks/libpak/bard"
-	"github.com/sclevine/spec"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/paketo-buildpacks/liberty/internal/core"
+	"github.com/paketo-buildpacks/libpak/bard"
+	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
 )
@@ -54,14 +55,14 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 			Expect(os.WriteFile(filepath.Join(testPath, "META-INF", "MANIFEST.MF"),
 				[]byte("Main-Class: com.java.HelloWorld"),
 				0644)).To(Succeed())
-			appBuildSource := core.NewAppBuildSource(testPath, bard.NewLogger(ioutil.Discard))
+			appBuildSource := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(ioutil.Discard))
 			ok, err := appBuildSource.Detect()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ok).To(BeFalse())
 		})
 
 		it("detects successfully when Main-Class is not set", func() {
-			appBuildSrc := core.NewAppBuildSource(testPath, bard.NewLogger(ioutil.Discard))
+			appBuildSrc := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(ioutil.Discard))
 			ok, err := appBuildSrc.Detect()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ok).To(BeTrue())
@@ -69,7 +70,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 
 		it("validates successfully when a compiled web archive is supplied", func() {
 			Expect(os.Mkdir(filepath.Join(testPath, "WEB-INF"), 0755)).To(Succeed())
-			appBuildSrc := core.NewAppBuildSource(testPath, bard.NewLogger(ioutil.Discard))
+			appBuildSrc := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(ioutil.Discard))
 			ok, err := appBuildSrc.ValidateApp()
 			Expect(err).To(Succeed())
 			Expect(ok).To(BeTrue())
@@ -78,14 +79,21 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 		it("validates successfully when a compiled enterprise archive is supplied", func() {
 			Expect(os.Mkdir(filepath.Join(testPath, "META-INF"), 0755)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(testPath, "META-INF", "application.xml"), []byte{}, 0644)).To(Succeed())
-			appBuildSrc := core.NewAppBuildSource(testPath, bard.NewLogger(ioutil.Discard))
+			appBuildSrc := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(ioutil.Discard))
 			ok, err := appBuildSrc.ValidateApp()
 			Expect(err).To(Succeed())
 			Expect(ok).To(BeTrue())
 		})
 
 		it("fails app validation when META-INF or application.xml not found", func() {
-			appBuildSrc := core.NewAppBuildSource(testPath, bard.NewLogger(ioutil.Discard))
+			appBuildSrc := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(ioutil.Discard))
+			ok, err := appBuildSrc.ValidateApp()
+			Expect(err).To(Succeed())
+			Expect(ok).To(BeFalse())
+		})
+
+		it("fails app validation when requested server is unknown", func() {
+			appBuildSrc := core.NewAppBuildSource(testPath, "foo", bard.NewLogger(ioutil.Discard))
 			ok, err := appBuildSrc.ValidateApp()
 			Expect(err).To(Succeed())
 			Expect(ok).To(BeFalse())

--- a/liberty/build.go
+++ b/liberty/build.go
@@ -18,6 +18,7 @@ package liberty
 
 import (
 	"fmt"
+
 	"github.com/buildpacks/libcnb"
 	"github.com/paketo-buildpacks/liberty/internal/core"
 	"github.com/paketo-buildpacks/liberty/internal/util"
@@ -26,14 +27,12 @@ import (
 )
 
 const (
-	openLibertyInstall      = "ol"
-	websphereLibertyInstall = "wlp"
-	noneInstall             = "none"
-
+	openLibertyInstall          = "ol"
+	websphereLibertyInstall     = "wlp"
+	noneInstall                 = "none"
 	openLibertyStackRuntimeRoot = "/opt/ol"
 	webSphereLibertyRuntimeRoot = "/opt/ibm"
-	
-	javaAppServerLiberty 		= "liberty"
+	javaAppServerLiberty        = "liberty"
 )
 
 type Build struct {
@@ -76,7 +75,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 	serverName, _ := cr.Resolve("BP_LIBERTY_SERVER_NAME")
 	serverBuildSrc := core.NewServerBuildSource(context.Application.Path, serverName, b.Logger)
-	appBuildSrc := core.NewAppBuildSource(context.Application.Path, b.Logger)
+	appBuildSrc := core.NewAppBuildSource(context.Application.Path, core.JavaAppServerLiberty, b.Logger)
 
 	buildSources := []core.BuildSource{
 		serverBuildSrc,
@@ -176,7 +175,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	} else {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to process install type: '%s'", installType)
 	}
-	
+
 	base := NewBase(context.Buildpack.Path, serverName, externalConfigurationDependency, cr, dc)
 	base.Logger = b.Logger
 	result.Layers = append(result.Layers, base)

--- a/liberty/build_test.go
+++ b/liberty/build_test.go
@@ -18,12 +18,13 @@ package liberty_test
 
 import (
 	"bytes"
-	"github.com/paketo-buildpacks/libpak"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/paketo-buildpacks/libpak"
 
 	"github.com/buildpacks/libcnb"
 	. "github.com/onsi/gomega"
@@ -81,7 +82,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect(result.Layers[1].Name()).To(Equal("open-liberty-runtime-full"))
 		Expect(result.Layers[2].Name()).To(Equal("base"))
 	})
-	
+
 	context("requested app server is not liberty", func() {
 		it.Before(func() {
 			Expect(os.Setenv("BP_JAVA_APP_SERVER", "notliberty")).To(Succeed())
@@ -231,7 +232,6 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				"server-name":              "defaultServer",
 				"packaged-server-usr-path": usrPath,
 			}}}
-			Expect(os.Setenv("BP_DEBUG", "true"))
 		})
 
 		it.After(func() {

--- a/liberty/detect.go
+++ b/liberty/detect.go
@@ -18,6 +18,7 @@ package liberty
 
 import (
 	"fmt"
+
 	"github.com/buildpacks/libcnb"
 	"github.com/paketo-buildpacks/liberty/internal/core"
 	"github.com/paketo-buildpacks/libpak"
@@ -28,7 +29,7 @@ const (
 	PlanEntryLiberty               = "liberty"
 	PlanEntryJRE                   = "jre"
 	PlanEntryJVMApplicationPackage = "jvm-application-package"
-	PlanEntryJavaAppServer		   = "java-app-server"
+	PlanEntryJavaAppServer         = "java-app-server"
 )
 
 type Detect struct {
@@ -42,8 +43,9 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 	}
 
 	serverName, _ := cr.Resolve("BP_LIBERTY_SERVER_NAME")
+	requestedAppServer, _ := cr.Resolve("BP_JAVA_APP_SERVER")
 	serverBuildSrc := core.NewServerBuildSource(context.Application.Path, serverName, d.Logger)
-	appBuildSrc := core.NewAppBuildSource(context.Application.Path, d.Logger)
+	appBuildSrc := core.NewAppBuildSource(context.Application.Path, requestedAppServer, d.Logger)
 
 	buildSources := []core.BuildSource{
 		serverBuildSrc,

--- a/liberty/detect_test.go
+++ b/liberty/detect_test.go
@@ -188,6 +188,22 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(result).To(Equal(libcnb.DetectResult{Pass: false}))
 	})
 
+	context("an unrecognized app server is set", func() {
+		it.Before(func() {
+			Expect(os.Setenv("BP_JAVA_APP_SERVER", "foo")).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("BP_JAVA_APP_SERVER")).To(Succeed())
+		})
+
+		it("fails if an unrecognized app server is set", func() {
+			result, err := detect.Detect(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(libcnb.DetectResult{Pass: false}))
+		})
+	})
+
 	context("when building a packaged server", func() {
 		it.Before(func() {
 			Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "wlp", "usr", "servers", "defaultServer", "apps", "test.war"), 0755)).To(Succeed())
@@ -258,43 +274,53 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			}))
 		})
 
-		it("works when there is more than one server and BP_LIBERTY_SERVER_NAME is set", func() {
-			Expect(os.Setenv("BP_LIBERTY_SERVER_NAME", "testServer")).To(Succeed())
-			testServerPath := filepath.Join(ctx.Application.Path, "wlp", "usr", "servers", "testServer")
-			Expect(os.MkdirAll(filepath.Join(testServerPath, "apps", "test.war"), 0755)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(testServerPath, "server.xml"), []byte("<server/>"), 0644)).To(Succeed())
+		context("BP_LIBERTY_SERVER_NAME is set", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BP_LIBERTY_SERVER_NAME", "testServer")).To(Succeed())
+			})
 
-			result, err := detect.Detect(ctx)
-			Expect(os.Unsetenv("BP_LIBERTY_SERVER_NAME")).To(Succeed())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(result).To(Equal(libcnb.DetectResult{
-				Pass: true,
-				Plans: []libcnb.BuildPlan{
-					{
-						Provides: []libcnb.BuildPlanProvide{
-							{Name: liberty.PlanEntryLiberty},
-							{Name: liberty.PlanEntryJavaAppServer},
-							{Name: liberty.PlanEntryJVMApplicationPackage},
-						},
+			it.After(func() {
+				Expect(os.Unsetenv("BP_LIBERTY_SERVER_NAME")).To(Succeed())
+			})
 
-						Requires: []libcnb.BuildPlanRequire{
-							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
-								"launch": true,
-								"build":  true,
-								"cache":  true,
-							}},
-							{Name: liberty.PlanEntryJavaAppServer},
-							{Name: liberty.PlanEntryJVMApplicationPackage},
-							{Name: liberty.PlanEntryLiberty},
+			it("works when there is more than one server and ", func() {
+				testServerPath := filepath.Join(ctx.Application.Path, "wlp", "usr", "servers", "testServer")
+				Expect(os.MkdirAll(filepath.Join(testServerPath, "apps", "test.war"), 0755)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(testServerPath, "server.xml"), []byte("<server/>"), 0644)).To(Succeed())
+
+				result, err := detect.Detect(ctx)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(Equal(libcnb.DetectResult{
+					Pass: true,
+					Plans: []libcnb.BuildPlan{
+						{
+							Provides: []libcnb.BuildPlanProvide{
+								{Name: liberty.PlanEntryLiberty},
+								{Name: liberty.PlanEntryJavaAppServer},
+								{Name: liberty.PlanEntryJVMApplicationPackage},
+							},
+
+							Requires: []libcnb.BuildPlanRequire{
+								{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
+									"launch": true,
+									"build":  true,
+									"cache":  true,
+								}},
+								{Name: liberty.PlanEntryJavaAppServer},
+								{Name: liberty.PlanEntryJVMApplicationPackage},
+								{Name: liberty.PlanEntryLiberty},
+							},
 						},
 					},
-				},
-			}))
+				}))
+			})
 		})
 
 		it("returns an error when there is more than one server and BP_LIBERTY_SERVER_NAME is not set", func() {
 			serverName := os.Getenv("BP_LIBERTY_SERVER_NAME")
 			Expect(serverName).To(BeEmpty())
+
 			testServerPath := filepath.Join(ctx.Application.Path, "wlp", "usr", "servers", "testServer")
 			Expect(os.MkdirAll(testServerPath, 0755)).To(Succeed())
 

--- a/liberty/detect_test.go
+++ b/liberty/detect_test.go
@@ -283,7 +283,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				Expect(os.Unsetenv("BP_LIBERTY_SERVER_NAME")).To(Succeed())
 			})
 
-			it("works when there is more than one server and ", func() {
+			it("works when there is more than one server ", func() {
 				testServerPath := filepath.Join(ctx.Application.Path, "wlp", "usr", "servers", "testServer")
 				Expect(os.MkdirAll(filepath.Join(testServerPath, "apps", "test.war"), 0755)).To(Succeed())
 				Expect(os.WriteFile(filepath.Join(testServerPath, "server.xml"), []byte("<server/>"), 0644)).To(Succeed())


### PR DESCRIPTION
## Summary

This is an extension to #93 that changes the implementation of `BP_JAVA_APP_SERVER`. This is now being implemented at detect time. This allows for better handling of the case where an invalid app server is specified. It also allows for faster feedback when there is a problem.

This matches the approach that has been provided for Apache Tomcat.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
