### PR TITLE
Validate build plan entries

### DIFF
--- a/liberty/build.go
+++ b/liberty/build.go
@@ -50,6 +50,13 @@ type Build struct {
 func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	result := libcnb.NewBuildResult()
 
+	pr := libpak.PlanEntryResolver{Plan: context.Plan}
+	if _, found, err := pr.Resolve(PlanEntryJavaAppServer); err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve plan entry\n%w", err)
+	} else if !found {
+		return result, nil
+	}
+
 	cr, err := libpak.NewConfigurationResolver(context.Buildpack, nil) // nil so we don't log config table
 	if err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to create configuration resolver\n%w", err)


### PR DESCRIPTION
## Summary

To work in conjunction with other buildpacks that provide application servers, we need to check the buildplan entries. If another buildpack has already consumed the build plan entry for java-app-server then the buildpack will immediately exit and take no action.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
