### PR TITLE
Don't cache JRE

### DIFF
--- a/liberty/detect.go
+++ b/liberty/detect.go
@@ -86,9 +86,7 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 				Requires: []libcnb.BuildPlanRequire{
 					{Name: PlanEntryJRE, Metadata: map[string]interface{}{
 						"launch": true,
-						"build":  true,
-						"cache":  true},
-					},
+					}},
 					{Name: PlanEntryJavaAppServer},
 					{Name: PlanEntryJVMApplicationPackage},
 					{Name: PlanEntryLiberty},

--- a/liberty/detect_test.go
+++ b/liberty/detect_test.go
@@ -75,8 +75,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
 							"launch": true,
-							"build":  true,
-							"cache":  true,
 						}},
 						{Name: liberty.PlanEntryJavaAppServer},
 						{Name: liberty.PlanEntryJVMApplicationPackage},
@@ -106,8 +104,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
 							"launch": true,
-							"build":  true,
-							"cache":  true,
 						}},
 						{Name: liberty.PlanEntryJavaAppServer},
 						{Name: liberty.PlanEntryJVMApplicationPackage},
@@ -138,8 +134,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
 							"launch": true,
-							"build":  true,
-							"cache":  true,
 						}},
 						{Name: liberty.PlanEntryJavaAppServer},
 						{Name: liberty.PlanEntryJVMApplicationPackage},
@@ -171,8 +165,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
 							"launch": true,
-							"build":  true,
-							"cache":  true,
 						}},
 						{Name: liberty.PlanEntryJavaAppServer},
 						{Name: liberty.PlanEntryJVMApplicationPackage},
@@ -234,8 +226,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Requires: []libcnb.BuildPlanRequire{
 							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
 								"launch": true,
-								"build":  true,
-								"cache":  true,
 							}},
 							{Name: liberty.PlanEntryJavaAppServer},
 							{Name: liberty.PlanEntryJVMApplicationPackage},
@@ -267,8 +257,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Requires: []libcnb.BuildPlanRequire{
 							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
 								"launch": true,
-								"build":  true,
-								"cache":  true,
 							}},
 							{Name: liberty.PlanEntryJavaAppServer},
 							{Name: liberty.PlanEntryJVMApplicationPackage},
@@ -310,8 +298,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							Requires: []libcnb.BuildPlanRequire{
 								{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
 									"launch": true,
-									"build":  true,
-									"cache":  true,
 								}},
 								{Name: liberty.PlanEntryJavaAppServer},
 								{Name: liberty.PlanEntryJVMApplicationPackage},
@@ -357,8 +343,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Requires: []libcnb.BuildPlanRequire{
 							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
 								"launch": true,
-								"build":  true,
-								"cache":  true,
 							}},
 							{Name: liberty.PlanEntryJavaAppServer},
 							{Name: liberty.PlanEntryJVMApplicationPackage},
@@ -397,8 +381,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Requires: []libcnb.BuildPlanRequire{
 							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
 								"launch": true,
-								"build":  true,
-								"cache":  true,
 							}},
 							{Name: liberty.PlanEntryJavaAppServer},
 							{Name: liberty.PlanEntryJVMApplicationPackage},
@@ -430,8 +412,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Requires: []libcnb.BuildPlanRequire{
 							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
 								"launch": true,
-								"build":  true,
-								"cache":  true,
 							}},
 							{Name: liberty.PlanEntryJavaAppServer},
 							{Name: liberty.PlanEntryJVMApplicationPackage},
@@ -459,8 +439,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						Requires: []libcnb.BuildPlanRequire{
 							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
 								"launch": true,
-								"build":  true,
-								"cache":  true,
 							}},
 							{Name: liberty.PlanEntryJavaAppServer},
 							{Name: liberty.PlanEntryJVMApplicationPackage},


### PR DESCRIPTION
The JRE layer needs to be present at runtime but does not need to be present at build time. If required a JDK layer should be present at build time instead.

Signed-off-by: Emily Casey <ecasey@vmware.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
