### PR TITLE
Move JRE to launch, add JDK for build

### DIFF
--- a/liberty/detect.go
+++ b/liberty/detect.go
@@ -28,6 +28,7 @@ import (
 const (
 	PlanEntryLiberty               = "liberty"
 	PlanEntryJRE                   = "jre"
+	PlanEntryJDK                   = "jdk"
 	PlanEntryJVMApplicationPackage = "jvm-application-package"
 	PlanEntryJavaAppServer         = "java-app-server"
 	PlanEntrySyft                  = "syft"
@@ -82,13 +83,9 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 					{Name: PlanEntryLiberty},
 					{Name: PlanEntryJavaAppServer},
 				},
-
 				Requires: []libcnb.BuildPlanRequire{
-					{Name: PlanEntryJRE, Metadata: map[string]interface{}{
-						"launch": true,
-						"build":  true,
-						"cache":  true},
-					},
+					{Name: PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+					{Name: PlanEntryJDK},
 					{Name: PlanEntryJavaAppServer},
 					{Name: PlanEntryJVMApplicationPackage},
 					{Name: PlanEntryLiberty},

--- a/liberty/detect_test.go
+++ b/liberty/detect_test.go
@@ -71,13 +71,9 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						{Name: liberty.PlanEntryLiberty},
 						{Name: liberty.PlanEntryJavaAppServer},
 					},
-
 					Requires: []libcnb.BuildPlanRequire{
-						{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
-							"launch": true,
-							"build":  true,
-							"cache":  true,
-						}},
+						{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+						{Name: liberty.PlanEntryJDK},
 						{Name: liberty.PlanEntryJavaAppServer},
 						{Name: liberty.PlanEntryJVMApplicationPackage},
 						{Name: liberty.PlanEntryLiberty},
@@ -104,11 +100,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					},
 
 					Requires: []libcnb.BuildPlanRequire{
-						{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
-							"launch": true,
-							"build":  true,
-							"cache":  true,
-						}},
+						{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+						{Name: liberty.PlanEntryJDK},
 						{Name: liberty.PlanEntryJavaAppServer},
 						{Name: liberty.PlanEntryJVMApplicationPackage},
 						{Name: liberty.PlanEntryLiberty},
@@ -136,11 +129,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					},
 
 					Requires: []libcnb.BuildPlanRequire{
-						{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
-							"launch": true,
-							"build":  true,
-							"cache":  true,
-						}},
+						{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+						{Name: liberty.PlanEntryJDK},
 						{Name: liberty.PlanEntryJavaAppServer},
 						{Name: liberty.PlanEntryJVMApplicationPackage},
 						{Name: liberty.PlanEntryLiberty},
@@ -169,11 +159,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					},
 
 					Requires: []libcnb.BuildPlanRequire{
-						{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
-							"launch": true,
-							"build":  true,
-							"cache":  true,
-						}},
+						{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+						{Name: liberty.PlanEntryJDK},
 						{Name: liberty.PlanEntryJavaAppServer},
 						{Name: liberty.PlanEntryJVMApplicationPackage},
 						{Name: liberty.PlanEntryLiberty},
@@ -232,11 +219,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 
 						Requires: []libcnb.BuildPlanRequire{
-							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
-								"launch": true,
-								"build":  true,
-								"cache":  true,
-							}},
+							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+							{Name: liberty.PlanEntryJDK},
 							{Name: liberty.PlanEntryJavaAppServer},
 							{Name: liberty.PlanEntryJVMApplicationPackage},
 							{Name: liberty.PlanEntryLiberty},
@@ -265,11 +249,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 
 						Requires: []libcnb.BuildPlanRequire{
-							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
-								"launch": true,
-								"build":  true,
-								"cache":  true,
-							}},
+							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+							{Name: liberty.PlanEntryJDK},
 							{Name: liberty.PlanEntryJavaAppServer},
 							{Name: liberty.PlanEntryJVMApplicationPackage},
 							{Name: liberty.PlanEntryLiberty},
@@ -308,11 +289,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 							},
 
 							Requires: []libcnb.BuildPlanRequire{
-								{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
-									"launch": true,
-									"build":  true,
-									"cache":  true,
-								}},
+								{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+								{Name: liberty.PlanEntryJDK},
 								{Name: liberty.PlanEntryJavaAppServer},
 								{Name: liberty.PlanEntryJVMApplicationPackage},
 								{Name: liberty.PlanEntryLiberty},
@@ -355,11 +333,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 
 						Requires: []libcnb.BuildPlanRequire{
-							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
-								"launch": true,
-								"build":  true,
-								"cache":  true,
-							}},
+							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+							{Name: liberty.PlanEntryJDK},
 							{Name: liberty.PlanEntryJavaAppServer},
 							{Name: liberty.PlanEntryJVMApplicationPackage},
 							{Name: liberty.PlanEntryLiberty},
@@ -395,11 +370,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 
 						Requires: []libcnb.BuildPlanRequire{
-							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
-								"launch": true,
-								"build":  true,
-								"cache":  true,
-							}},
+							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+							{Name: liberty.PlanEntryJDK},
 							{Name: liberty.PlanEntryJavaAppServer},
 							{Name: liberty.PlanEntryJVMApplicationPackage},
 							{Name: liberty.PlanEntryLiberty},
@@ -428,11 +400,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 
 						Requires: []libcnb.BuildPlanRequire{
-							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
-								"launch": true,
-								"build":  true,
-								"cache":  true,
-							}},
+							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+							{Name: liberty.PlanEntryJDK},
 							{Name: liberty.PlanEntryJavaAppServer},
 							{Name: liberty.PlanEntryJVMApplicationPackage},
 							{Name: liberty.PlanEntryLiberty},
@@ -457,11 +426,8 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 						},
 
 						Requires: []libcnb.BuildPlanRequire{
-							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{
-								"launch": true,
-								"build":  true,
-								"cache":  true,
-							}},
+							{Name: liberty.PlanEntryJRE, Metadata: map[string]interface{}{"launch": true}},
+							{Name: liberty.PlanEntryJDK},
 							{Name: liberty.PlanEntryJavaAppServer},
 							{Name: liberty.PlanEntryJVMApplicationPackage},
 							{Name: liberty.PlanEntryLiberty},


### PR DESCRIPTION
## Summary

This change moves the JRE to be a launch-only layer. This addresses issues when integrating Liberty with the larger Java composite buildpack. Because we need Java during build, this change also adds the JDK as a build + cache layer, which will make it available during build.

This will help because it reduces the caching requirements of the JRE layer across all builds and all buildpacks, not just Liberty. It comes at the expense of requiring the JDK to be downloaded when building a WAR file from pre-compiled bits (does not impact building from source).

Superceeds #144 

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
