### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `gcr.io/paketo-buildpacks/liberty`
 
-The Paketo Liberty Buildpack is a Cloud-Native Buildpack that contributes Open Liberty or WebSphere Liberty for Java EE support.
+The Paketo Buildpack for Liberty is a Cloud-Native Buildpack that contributes Open Liberty or WebSphere Liberty for Java EE support.
 
 ## Behavior
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/liberty"
   id = "paketo-buildpacks/liberty"
   keywords = ["java", "javaee", "liberty"]
-  name = "Paketo Liberty Buildpack"
+  name = "Paketo Buildpack for Liberty"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Liberty Buildpack' to 'Paketo Buildpack for Liberty'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
