### PR TITLE
Fix caching for Liberty config layer.

### DIFF
--- a/internal/core/buildsrc.go
+++ b/internal/core/buildsrc.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"fmt"
+	"github.com/paketo-buildpacks/libpak/sherpa"
 	"path/filepath"
 
 	"github.com/paketo-buildpacks/liberty/internal/server"
@@ -149,7 +150,7 @@ func (s ServerBuildSource) Detect() (bool, error) {
 		return false, nil
 	}
 
-	return util.FileExists(filepath.Join(serverPath, "server.xml"))
+	return sherpa.FileExists(filepath.Join(serverPath, "server.xml"))
 }
 
 func (s ServerBuildSource) DefaultServerName() (string, error) {
@@ -224,7 +225,7 @@ func (s ServerBuildSource) UserPath() (string, error) {
 	}
 	for _, dir := range dirs {
 		path := filepath.Join(s.InstallRoot, dir)
-		exists, err := util.DirExists(path)
+		exists, err := sherpa.DirExists(path)
 		if err != nil {
 			return "", nil
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -141,11 +141,11 @@ func SetUserDirectory(srcUserPath string, destUserPath string, serverName string
 	// Copy the configDropins directory to the new user directory. This is needed by Liberty runtimes provided in the
 	// stack run image
 	configDropinsDir := filepath.Join(destUserPath, "servers", "defaultServer", "configDropins")
-	if configDropinsFound, err := util.DirExists(configDropinsDir); err != nil {
+	if configDropinsFound, err := sherpa.DirExists(configDropinsDir); err != nil {
 		return fmt.Errorf("unable to read configDropins directory\n%w", err)
 	} else if configDropinsFound {
 		newConfigDropinsDir := filepath.Join(srcUserPath, "servers", serverName, "configDropins")
-		if err := util.CopyDir(configDropinsDir, newConfigDropinsDir); err != nil {
+		if err := sherpa.CopyDir(configDropinsDir, newConfigDropinsDir); err != nil {
 			return fmt.Errorf("unable to copy configDropins to new user directory\n%w", err)
 		}
 	}
@@ -176,7 +176,7 @@ func HasInstalledApps(serverPath string) (bool, error) {
 func GetServerList(userPath string) ([]string, error) {
 	serversPath := filepath.Join(userPath, "servers")
 
-	serversExists, err := util.FileExists(serversPath)
+	serversExists, err := sherpa.DirExists(serversPath)
 	if err != nil {
 		return []string{}, err
 	}

--- a/internal/util/app.go
+++ b/internal/util/app.go
@@ -19,6 +19,7 @@ package util
 import (
 	"fmt"
 	"github.com/paketo-buildpacks/libjvm"
+	"github.com/paketo-buildpacks/libpak/sherpa"
 	"io/ioutil"
 	"path/filepath"
 	"strings"
@@ -27,13 +28,13 @@ import (
 // IsJvmApplicationPackage will return true if `META-INF/application.xml` or `WEB-INF/` exists, which happens when a
 // compiled artifact is supplied.
 func IsJvmApplicationPackage(appPath string) (bool, error) {
-	if appXMLPresent, err := FileExists(filepath.Join(appPath, "META-INF", "application.xml")); err != nil {
+	if appXMLPresent, err := sherpa.FileExists(filepath.Join(appPath, "META-INF", "application.xml")); err != nil {
 		return false, fmt.Errorf("unable to check application.xml\n%w", err)
 	} else if appXMLPresent {
 		return true, nil
 	}
 
-	if webInfPresent, err := DirExists(filepath.Join(appPath, "WEB-INF")); err != nil {
+	if webInfPresent, err := sherpa.DirExists(filepath.Join(appPath, "WEB-INF")); err != nil {
 		return false, fmt.Errorf("unable to check WEB-INF\n%w", err)
 	} else if webInfPresent {
 		return true, nil
@@ -54,14 +55,14 @@ func ManifestHasMainClassDefined(appPath string) (bool, error) {
 }
 
 func GetApps(path string) ([]string, error) {
-	if exists, err := DirExists(path); err != nil {
+	if exists, err := sherpa.DirExists(path); err != nil {
 		return []string{}, err
 	} else if !exists {
 		return []string{}, nil
 	}
 
 	// Return the empty list for expanded EAR applications
-	if exists, err := FileExists(filepath.Join(path, "META-INF", "application.xml")); err != nil {
+	if exists, err := sherpa.FileExists(filepath.Join(path, "META-INF", "application.xml")); err != nil {
 		return []string{}, err
 	} else if exists {
 		return []string{}, nil

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -19,8 +19,6 @@ package util
 import (
 	"fmt"
 	"github.com/paketo-buildpacks/libpak/sherpa"
-	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -38,79 +36,6 @@ func DeleteAndLinkPath(src, dest string) error {
 		return fmt.Errorf("unable to symlink file from '%s' to '%s'\n%w", src, dest, err)
 	}
 	return nil
-}
-
-// FileExists returns true if the path exists.
-func FileExists(path string) (bool, error) {
-	if _, err := os.Stat(path); err == nil {
-		return true, nil
-	} else if os.IsNotExist(err) {
-		return false, nil
-	} else {
-		return false, err
-	}
-}
-
-// DirExists returns true if the path exists and is a directory.
-func DirExists(path string) (bool, error) {
-	if stat, err := os.Stat(path); err == nil {
-		return stat.IsDir(), nil
-	} else if os.IsNotExist(err) {
-		return false, nil
-	} else {
-		return false, err
-	}
-}
-
-// CopyDir copies a directory and all of its contents from the source path to the destination.
-func CopyDir(src, dest string) error {
-	entries, err := ioutil.ReadDir(src)
-	if err != nil {
-		return err
-	}
-
-	for _, entry := range entries {
-		srcPath := filepath.Join(src, entry.Name())
-		destPath := filepath.Join(dest, entry.Name())
-
-		fileInfo, err := os.Stat(srcPath)
-		if err != nil {
-			return err
-		}
-
-		switch fileInfo.Mode() & os.ModeType {
-		case os.ModeDir:
-			if err := os.MkdirAll(destPath, 0755); err != nil {
-				return err
-			}
-			if err := CopyDir(srcPath, destPath); err != nil {
-				return err
-			}
-		default:
-			if err := CopyFile(srcPath, destPath); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-// CopyFile copies a file from the source path to the destination path.
-func CopyFile(src, dest string) error {
-	srcFile, err := os.Open(src)
-	defer srcFile.Close()
-	if err != nil {
-		return err
-	}
-
-	destFile, err := os.Create(dest)
-	if err != nil {
-		return err
-	}
-	defer destFile.Close()
-
-	_, err = io.Copy(destFile, srcFile)
-	return err
 }
 
 func GetFiles(root string, pattern string) ([]string, error) {

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"fmt"
+	"github.com/paketo-buildpacks/libpak/sherpa"
 	"io"
 	"io/ioutil"
 	"os"
@@ -110,4 +111,34 @@ func CopyFile(src, dest string) error {
 
 	_, err = io.Copy(destFile, srcFile)
 	return err
+}
+
+func GetFiles(root string, pattern string) ([]string, error) {
+	var files []string
+	if exists, err := sherpa.DirExists(root); err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, nil
+	}
+
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		matched, err := filepath.Match(pattern, filepath.Base(path))
+		if err != nil {
+			return err
+		}
+		if matched {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
 }

--- a/liberty/base.go
+++ b/liberty/base.go
@@ -199,7 +199,7 @@ func (b Base) createServerDirectory(layer libcnb.Layer) error {
 
 func (b Base) contributeConfig(serverPath string, layer libcnb.Layer) error {
 	serverConfigPath := filepath.Join(serverPath, "server.xml")
-	exists, err := util.FileExists(serverConfigPath)
+	exists, err := sherpa.FileExists(serverConfigPath)
 	if err != nil {
 		return fmt.Errorf("unable to check if server.xml exists\n%w", err)
 	}
@@ -219,11 +219,13 @@ func (b Base) contributeConfig(serverPath string, layer libcnb.Layer) error {
 		if err != nil {
 			return fmt.Errorf("unable to execute template\n%w", err)
 		}
-	} else {
 	}
 
-	err = util.CopyFile(filepath.Join(b.BuildpackPath, "templates", "expose-default-endpoint.xml"),
-		filepath.Join(serverPath, "configDropins", "defaults", "expose-default-endpoint.xml"))
+	file, err := os.Open(filepath.Join(b.BuildpackPath, "templates", "expose-default-endpoint.xml"))
+	if err != nil {
+		return fmt.Errorf("unable to open endpoint config\n%w", err)
+	}
+	err = sherpa.CopyFile(file, filepath.Join(serverPath, "configDropins", "defaults", "expose-default-endpoint.xml"))
 	if err != nil {
 		return fmt.Errorf("unable to copy endpoint config\n%w", err)
 	}
@@ -251,7 +253,7 @@ func (b Base) contributeApp(layer libcnb.Layer, config server.Config) error {
 	}
 
 	// Expand app if needed
-	isDir, err := util.DirExists(appPath)
+	isDir, err := sherpa.DirExists(appPath)
 	if err != nil {
 		return fmt.Errorf("unable to check if app path is a directory\n%w", err)
 	}

--- a/liberty/base.go
+++ b/liberty/base.go
@@ -21,11 +21,9 @@ import (
 	"fmt"
 	"github.com/paketo-buildpacks/liberty/internal/core"
 	"github.com/paketo-buildpacks/liberty/internal/server"
-	"github.com/paketo-buildpacks/libpak/bindings"
 	"github.com/paketo-buildpacks/libpak/crush"
 	"github.com/paketo-buildpacks/libpak/sherpa"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,43 +44,61 @@ type Base struct {
 	ServerName            string
 	Features              []string
 	UserFeatureDescriptor *FeatureDescriptor
-	Bindings              libcnb.Bindings
+	LibertyBinding        libcnb.Binding
 }
 
-func NewBase(appPath string, buildpackPath string, serverName string, features []string, userFeatureDescriptor *FeatureDescriptor, binds libcnb.Bindings, logger bard.Logger) Base {
+func NewBase(
+	appPath string,
+	buildpackPath string,
+	serverName string,
+	features []string,
+	userFeatureDescriptor *FeatureDescriptor,
+	libertyBinding libcnb.Binding,
+	logger bard.Logger,
+) Base {
 	workspaceSum, err := sherpa.NewFileListingHash(appPath)
 	if err != nil {
-		logger.Infof(color.RedString("unable to calculate checksum of workspace directory\n%w", err))
+		logger.Info(color.RedString("unable to calculate checksum of workspace directory\n%w", err))
 	}
 	var enabledUserFeatures []string
 	for _, feature := range userFeatureDescriptor.Features {
 		enabledUserFeatures = append(enabledUserFeatures, fmt.Sprintf("%s-%s", feature.Name, feature.Version))
 	}
 
+	expectedMetadata := map[string]interface{}{
+		"serverName":   serverName,
+		"features":     features,
+		"userFeatures": enabledUserFeatures,
+		"workspaceSum": workspaceSum,
+	}
+
+	// Add checksum for /templates if provided
+	templatesSum, err := getTemplatesChecksum()
+	if err == nil {
+		if templatesSum != "" {
+			expectedMetadata["templatesSum"] = templatesSum
+		}
+	} else {
+		logger.Info(color.RedString("unable to get checksum for templates\n%w", err))
+	}
+
 	contributor := libpak.NewLayerContributor(
 		"Open Liberty Config",
-		map[string]interface{}{
-			"serverName":   serverName,
-			"features":     features,
-			"userFeatures": enabledUserFeatures,
-			"workspaceSum": workspaceSum,
-		},
+		expectedMetadata,
 		libcnb.LayerTypes{
 			Launch: true,
 		})
 
-	b := Base{
+	return Base{
 		ApplicationPath:       appPath,
 		BuildpackPath:         buildpackPath,
 		LayerContributor:      contributor,
 		ServerName:            serverName,
 		Features:              features,
 		UserFeatureDescriptor: userFeatureDescriptor,
-		Bindings:              binds,
+		LibertyBinding:        libertyBinding,
 		Logger:                logger,
 	}
-
-	return b
 }
 
 func (b Base) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
@@ -117,14 +133,6 @@ func (b Base) contribute(layer libcnb.Layer) error {
 		return nil
 	}
 
-	binding, _, err := bindings.ResolveOne(b.Bindings, bindings.OfType("liberty"))
-	if err != nil {
-		return fmt.Errorf("unable to resolve liberty bindings\n%w", err)
-	}
-	if err := b.contributeConfigTemplates(layer, binding); err != nil {
-		return fmt.Errorf("unable to contribute config templates\n%w", err)
-	}
-
 	serverPath := filepath.Join(layer.Path, "wlp", "usr", "servers", b.ServerName)
 	err = b.createServerDirectory(layer)
 	if err != nil {
@@ -155,7 +163,7 @@ func (b Base) contribute(layer libcnb.Layer) error {
 		b.Logger.Info(color.YellowString("Reminder: Do not include secrets in %s; this file has been included in the image and that can leak your secrets", config))
 	}
 
-	err = b.contributeConfig(serverPath, layer)
+	err = b.contributeConfig(serverPath)
 	if err != nil {
 		return fmt.Errorf("unable to contribute config\n%w", err)
 	}
@@ -197,14 +205,17 @@ func (b Base) createServerDirectory(layer libcnb.Layer) error {
 	})
 }
 
-func (b Base) contributeConfig(serverPath string, layer libcnb.Layer) error {
+func (b Base) contributeConfig(serverPath string) error {
 	serverConfigPath := filepath.Join(serverPath, "server.xml")
 	exists, err := sherpa.FileExists(serverConfigPath)
 	if err != nil {
 		return fmt.Errorf("unable to check if server.xml exists\n%w", err)
 	}
 	if !exists {
-		templatePath := b.getConfigTemplate(layer.Path, "server.tmpl")
+		templatePath, err := b.getConfigTemplate("server.tmpl")
+		if err != nil {
+			return fmt.Errorf("unable to get server config template\n%w", err)
+		}
 		t, err := template.New("server.tmpl").ParseFiles(templatePath)
 		if err != nil {
 			return fmt.Errorf("unable to create server template\n%w", err)
@@ -221,7 +232,11 @@ func (b Base) contributeConfig(serverPath string, layer libcnb.Layer) error {
 		}
 	}
 
-	file, err := os.Open(filepath.Join(b.BuildpackPath, "templates", "expose-default-endpoint.xml"))
+	endpointTemplate, err := b.getConfigTemplate("expose-default-endpoint.xml")
+	if err != nil {
+		return fmt.Errorf("unable to get endpoint config\n%w", err)
+	}
+	file, err := os.Open(endpointTemplate)
 	if err != nil {
 		return fmt.Errorf("unable to open endpoint config\n%w", err)
 	}
@@ -289,7 +304,10 @@ func (b Base) contributeApp(layer libcnb.Layer, config server.Config) error {
 		Type:        appType,
 	}
 
-	templatePath := b.getConfigTemplate(layer.Path, "app.tmpl")
+	templatePath, err := b.getConfigTemplate("app.tmpl")
+	if err != nil {
+		return fmt.Errorf("unable to get app config template\n%w", err)
+	}
 	t, err := template.New("app.tmpl").ParseFiles(templatePath)
 	if err != nil {
 		return fmt.Errorf("unable to create app template\n%w", err)
@@ -305,50 +323,6 @@ func (b Base) contributeApp(layer libcnb.Layer, config server.Config) error {
 	err = t.Execute(file, appConfig)
 	if err != nil {
 		return fmt.Errorf("unable to execute template\n%w", err)
-	}
-	return nil
-}
-
-func (b Base) contributeConfigTemplates(layer libcnb.Layer, binding libcnb.Binding) error {
-	// Create config templates directory
-	templateDir := filepath.Join(layer.Path, "templates")
-	if err := os.MkdirAll(templateDir, 0755); err != nil {
-		return fmt.Errorf("unable to create config template directory '%s'\n%w", templateDir, err)
-	}
-
-	srcDir := filepath.Join(b.BuildpackPath, "templates")
-	entries, err := ioutil.ReadDir(srcDir)
-	if err != nil {
-		return fmt.Errorf("unable to read source directory\n%w", err)
-	}
-
-	for _, entry := range entries {
-		err := func() error {
-			srcPath := filepath.Join(srcDir, entry.Name())
-
-			// Check if a custom template was provided in a binding
-			if binding, ok := binding.SecretFilePath(entry.Name()); ok {
-				b.Logger.Bodyf("Using custom template: %s", binding)
-				srcPath = binding
-			}
-
-			b.Logger.Bodyf("Copying %v", srcPath)
-			destPath := filepath.Join(templateDir, entry.Name())
-			in, err := os.Open(srcPath)
-			if err != nil {
-				return fmt.Errorf("unable to open source template file '%s'\n%w", srcPath, err)
-			}
-			defer in.Close()
-			err = sherpa.CopyFile(in, destPath)
-			if err != nil {
-				return fmt.Errorf("unable to copy template from '%s' -> '%s'\n%w", srcPath, destPath, err)
-			}
-			return nil
-		}()
-
-		if err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -372,7 +346,7 @@ func (b Base) contributeUserFeatures(layer libcnb.Layer) error {
 	featureInstaller := NewFeatureInstaller(
 		filepath.Join(layer.Path, "wlp"),
 		b.ServerName,
-		filepath.Join(layer.Path, "templates", "features.tmpl"),
+		filepath.Join(b.BuildpackPath, "templates", "features.tmpl"),
 		b.UserFeatureDescriptor.Features)
 
 	if err := featureInstaller.Install(); err != nil {
@@ -395,6 +369,40 @@ type ApplicationConfig struct {
 	Type        string
 }
 
-func (b Base) getConfigTemplate(layerPath string, template string) string {
-	return filepath.Join(layerPath, "templates", template)
+func (b Base) getConfigTemplate(template string) (string, error) {
+	// Check if the config template has been provided in /templates
+	templatesPath := filepath.Join("/", "templates", template)
+	exists, err := sherpa.FileExists(templatesPath)
+	if err != nil {
+		return "", fmt.Errorf("unable to check for template at %s\n%w", templatesPath, err)
+	}
+	if exists {
+		return templatesPath, nil
+	}
+
+	// Check if the config template has been provided in a liberty binding
+	// TODO: Remove this in next major release
+	if bindingPath, ok := b.LibertyBinding.SecretFilePath(template); ok {
+		b.Logger.Info(color.YellowString("Warning: Providing config templates via binding is deprecated. Mount the config templates to /templates instead."))
+		return bindingPath, nil
+	}
+
+	// Return the default config template
+	return filepath.Join(b.BuildpackPath, "templates", template), nil
+}
+
+func getTemplatesChecksum() (string, error) {
+	templatesPath := filepath.Join("/", "templates")
+	exists, err := sherpa.DirExists(templatesPath)
+	if err != nil {
+		return "", fmt.Errorf("unable to check if /templates mount provided\n%w", err)
+	}
+	if !exists {
+		return "", nil
+	}
+	templatesSum, err := sherpa.NewFileListingHash(templatesPath)
+	if err != nil {
+		return "", fmt.Errorf("unable to get checksum for %s\n%w", templatesPath, err)
+	}
+	return templatesSum, nil
 }

--- a/liberty/base_test.go
+++ b/liberty/base_test.go
@@ -92,7 +92,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			"defaultServer",
 			[]string{"jsp-2.3"},
 			&liberty.FeatureDescriptor{},
-			nil,
+			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
 		)
 		layer, err := ctx.Layers.Layer("test-layer")
@@ -102,12 +102,6 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(layer.Launch).To(BeTrue())
-
-		// Check for templates
-		Expect(filepath.Join(layer.Path, "templates")).To(BeADirectory())
-		Expect(filepath.Join(layer.Path, "templates", "app.tmpl")).To(BeARegularFile())
-		Expect(filepath.Join(layer.Path, "templates", "expose-default-endpoint.xml")).To(BeARegularFile())
-		Expect(filepath.Join(layer.Path, "templates", "server.tmpl")).To(BeARegularFile())
 
 		// Check app
 		appPath, err := filepath.EvalSymlinks(filepath.Join(filepath.Join(layer.Path, "wlp", "usr", "servers", "defaultServer", "apps", "app")))
@@ -129,7 +123,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			"defaultServer",
 			[]string{"jsp-2.3"},
 			&liberty.FeatureDescriptor{},
-			nil,
+			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
 		)
 		layer, err := ctx.Layers.Layer("test-layer")
@@ -161,7 +155,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			"defaultServer",
 			[]string{"jaxrs-2.1", "cdi-2.0"},
 			&liberty.FeatureDescriptor{},
-			nil,
+			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
 		)
 		layer, err := ctx.Layers.Layer("test-layer")
@@ -203,7 +197,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			"defaultServer",
 			[]string{"jsp-2.3"},
 			&liberty.FeatureDescriptor{},
-			nil,
+			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
 		)
 		layer, err := ctx.Layers.Layer("test-layer")
@@ -239,7 +233,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			"defaultServer",
 			[]string{"jsp-2.3"},
 			&liberty.FeatureDescriptor{},
-			nil,
+			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
 		)
 		layer, err := ctx.Layers.Layer("test-layer")
@@ -267,7 +261,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			"defaultServer",
 			[]string{"jsp-2.3"},
 			&liberty.FeatureDescriptor{},
-			nil,
+			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
 		)
 		layer, err := ctx.Layers.Layer("test-layer")
@@ -295,7 +289,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			"testServer",
 			[]string{"jsp-2.3"},
 			&liberty.FeatureDescriptor{},
-			nil,
+			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
 		)
 		layer, err := ctx.Layers.Layer("test-layer")
@@ -348,7 +342,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			"defaultServer",
 			[]string{"jsp-2.3"},
 			userFeatureDescriptor,
-			nil,
+			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
 		)
 

--- a/liberty/base_test.go
+++ b/liberty/base_test.go
@@ -31,7 +31,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func testBase(t *testing.T, context spec.G, it spec.S) {
+func testBase(t *testing.T, _ spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
@@ -86,8 +86,15 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.Mkdir(filepath.Join(ctx.Application.Path, "WEB-INF"), 0755)).To(Succeed())
 		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "WEB-INF", "web.xml"), []byte{}, 0644))
 
-		base := liberty.NewBase(ctx.Application.Path, ctx.Buildpack.Path, "defaultServer", "kernel", nil, &liberty.FeatureDescriptor{}, nil)
-		base.Logger = bard.NewLogger(os.Stdout)
+		base := liberty.NewBase(
+			ctx.Application.Path,
+			ctx.Buildpack.Path,
+			"defaultServer",
+			[]string{"jsp-2.3"},
+			&liberty.FeatureDescriptor{},
+			nil,
+			bard.NewLogger(os.Stdout),
+		)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -116,8 +123,15 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("contributes a default server.xml", func() {
-		base := liberty.NewBase(ctx.Application.Path, ctx.Buildpack.Path, "defaultServer", "kernel", nil, &liberty.FeatureDescriptor{}, nil)
-		base.Logger = bard.NewLogger(os.Stdout)
+		base := liberty.NewBase(
+			ctx.Application.Path,
+			ctx.Buildpack.Path,
+			"defaultServer",
+			[]string{"jsp-2.3"},
+			&liberty.FeatureDescriptor{},
+			nil,
+			bard.NewLogger(os.Stdout),
+		)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -141,8 +155,15 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	it("contributes features to server.xml", func() {
-		base := liberty.NewBase(ctx.Application.Path, ctx.Buildpack.Path, "defaultServer", "kernel", []string{"jaxrs-2.1", "cdi-2.0"}, &liberty.FeatureDescriptor{}, nil)
-		base.Logger = bard.NewLogger(os.Stdout)
+		base := liberty.NewBase(
+			ctx.Application.Path,
+			ctx.Buildpack.Path,
+			"defaultServer",
+			[]string{"jaxrs-2.1", "cdi-2.0"},
+			&liberty.FeatureDescriptor{},
+			nil,
+			bard.NewLogger(os.Stdout),
+		)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -174,8 +195,15 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "server.env"), []byte("TEST_ENV=foo"), 0644)).To(Succeed())
 		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "bootstrap.properties"), []byte("test.property=foo"), 0644)).To(Succeed())
 
-		base := liberty.NewBase(ctx.Application.Path, ctx.Buildpack.Path, "defaultServer", "kernel", nil, &liberty.FeatureDescriptor{}, nil)
-		base.Logger = bard.NewLogger(os.Stdout)
+		base := liberty.NewBase(
+			ctx.Application.Path,
+			ctx.Buildpack.Path,
+			"defaultServer",
+			[]string{"jsp-2.3"},
+			&liberty.FeatureDescriptor{},
+			nil,
+			bard.NewLogger(os.Stdout),
+		)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -203,8 +231,15 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.MkdirAll(serverSourcePath, 0755)).To(Succeed())
 		Expect(os.WriteFile(filepath.Join(serverSourcePath, "server.xml"), []byte("<server />"), 0644))
 
-		base := liberty.NewBase(ctx.Application.Path, ctx.Buildpack.Path, "defaultServer", "kernel", nil, &liberty.FeatureDescriptor{}, nil)
-		base.Logger = bard.NewLogger(os.Stdout)
+		base := liberty.NewBase(
+			ctx.Application.Path,
+			ctx.Buildpack.Path,
+			"defaultServer",
+			[]string{"jsp-2.3"},
+			&liberty.FeatureDescriptor{},
+			nil,
+			bard.NewLogger(os.Stdout),
+		)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -224,8 +259,15 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.MkdirAll(serverSourcePath, 0755)).To(Succeed())
 		Expect(os.WriteFile(filepath.Join(serverSourcePath, "server.xml"), []byte("<server />"), 0644))
 
-		base := liberty.NewBase(ctx.Application.Path, ctx.Buildpack.Path, "defaultServer", "kernel", nil, &liberty.FeatureDescriptor{}, nil)
-		base.Logger = bard.NewLogger(os.Stdout)
+		base := liberty.NewBase(
+			ctx.Application.Path,
+			ctx.Buildpack.Path,
+			"defaultServer",
+			[]string{"jsp-2.3"},
+			&liberty.FeatureDescriptor{},
+			nil,
+			bard.NewLogger(os.Stdout),
+		)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -245,8 +287,15 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 		Expect(os.MkdirAll(serverSourcePath, 0755)).To(Succeed())
 		Expect(os.WriteFile(filepath.Join(serverSourcePath, "server.xml"), []byte("<server />"), 0644))
 
-		base := liberty.NewBase(ctx.Application.Path, ctx.Buildpack.Path, "testServer", "kernel", nil, &liberty.FeatureDescriptor{}, nil)
-		base.Logger = bard.NewLogger(os.Stdout)
+		base := liberty.NewBase(
+			ctx.Application.Path,
+			ctx.Buildpack.Path,
+			"testServer",
+			[]string{"jsp-2.3"},
+			&liberty.FeatureDescriptor{},
+			nil,
+			bard.NewLogger(os.Stdout),
+		)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -291,8 +340,15 @@ func testBase(t *testing.T, context spec.G, it spec.S) {
 		logger := bard.NewLogger(os.Stdout)
 		userFeatureDescriptor, err := liberty.ReadFeatureDescriptor(featuresRoot, logger)
 		Expect(err).ToNot(HaveOccurred())
-		base := liberty.NewBase(ctx.Application.Path, ctx.Buildpack.Path, "defaultServer", "kernel", nil, userFeatureDescriptor, nil)
-		base.Logger = logger
+		base := liberty.NewBase(
+			ctx.Application.Path,
+			ctx.Buildpack.Path,
+			"defaultServer",
+			[]string{"jsp-2.3"},
+			userFeatureDescriptor,
+			nil,
+			bard.NewLogger(os.Stdout),
+		)
 
 		layer, err = base.Contribute(layer)
 		Expect(err).ToNot(HaveOccurred())

--- a/liberty/base_test.go
+++ b/liberty/base_test.go
@@ -17,7 +17,7 @@
 package liberty_test
 
 import (
-	"github.com/paketo-buildpacks/liberty/internal/util"
+	"github.com/paketo-buildpacks/libpak/sherpa"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -190,7 +190,9 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 
 	it("contributes server.xml and compiled artifact", func() {
 		// Set up app and server config
-		Expect(util.CopyFile(filepath.Join("testdata", "test.war"), filepath.Join(ctx.Application.Path, "test.war"))).To(Succeed())
+		file, err := os.Open(filepath.Join("testdata", "test.war"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sherpa.CopyFile(file, filepath.Join(ctx.Application.Path, "test.war"))).To(Succeed())
 		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "server.xml"), []byte("<server/>"), 0644)).To(Succeed())
 		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "server.env"), []byte("TEST_ENV=foo"), 0644)).To(Succeed())
 		Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "bootstrap.properties"), []byte("test.property=foo"), 0644)).To(Succeed())

--- a/liberty/build.go
+++ b/liberty/build.go
@@ -19,6 +19,7 @@ package liberty
 import (
 	"fmt"
 	"github.com/heroku/color"
+	"github.com/paketo-buildpacks/libpak/bindings"
 	sherpa "github.com/paketo-buildpacks/libpak/sherpa"
 	"strings"
 
@@ -185,13 +186,17 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	if err != nil {
 		return libcnb.BuildResult{}, err
 	}
+	binding, _, err := bindings.ResolveOne(context.Platform.Bindings, bindings.OfType("liberty"))
+	if err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve liberty bindings\n%w", err)
+	}
 	base := NewBase(
 		context.Application.Path,
 		context.Buildpack.Path,
 		serverName,
 		featureList,
 		userFeatureDescriptor,
-		context.Platform.Bindings,
+		binding,
 		b.Logger,
 	)
 	result.Layers = append(result.Layers, base)

--- a/liberty/build.go
+++ b/liberty/build.go
@@ -19,12 +19,12 @@ package liberty
 import (
 	"fmt"
 	"github.com/heroku/color"
+	sherpa "github.com/paketo-buildpacks/libpak/sherpa"
 	"strings"
 
 	"github.com/buildpacks/libcnb"
 	"github.com/paketo-buildpacks/liberty/internal/core"
 	"github.com/paketo-buildpacks/liberty/internal/server"
-	"github.com/paketo-buildpacks/liberty/internal/util"
 	"github.com/paketo-buildpacks/libpak"
 	"github.com/paketo-buildpacks/libpak/bard"
 	"github.com/paketo-buildpacks/libpak/effect"
@@ -278,7 +278,7 @@ func (b Build) buildStackRuntime(serverName string, result *libcnb.BuildResult) 
 }
 
 func createStackRuntimeProcess(serverName string) (libcnb.Process, error) {
-	olExists, err := util.DirExists(openLibertyStackRuntimeRoot)
+	olExists, err := sherpa.DirExists(openLibertyStackRuntimeRoot)
 	if err != nil {
 		return libcnb.Process{}, fmt.Errorf("unable to check Open Liberty stack runtime root exists\n%w", err)
 	}
@@ -292,7 +292,7 @@ func createStackRuntimeProcess(serverName string) (libcnb.Process, error) {
 		}, nil
 	}
 
-	wlpExists, err := util.DirExists(webSphereLibertyRuntimeRoot)
+	wlpExists, err := sherpa.DirExists(webSphereLibertyRuntimeRoot)
 	if err != nil {
 		return libcnb.Process{}, fmt.Errorf("unable to WebSphere Open Liberty stack runtime root exists\n%w", err)
 	}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Fixes #168. Fix caching of the base layer so that users do not need to clear the cache to update their config.

## Use Cases
Allows users to update their Liberty server config without clearing their cache.


## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
