### PR TITLE
Re-include helper.

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -28,7 +28,7 @@ api = "0.7"
     uri = "https://github.com/paketo-buildpacks/liberty/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/main", "buildpack.toml", "templates/server.tmpl", "templates/app.tmpl", "templates/features.tmpl", "templates/expose-default-endpoint.xml"]
+  include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/main", "bin/helper", "buildpack.toml", "templates/server.tmpl", "templates/app.tmpl", "templates/features.tmpl", "templates/expose-default-endpoint.xml"]
   pre-package = "scripts/build.sh"
 
   [[metadata.configurations]]

--- a/helper/init_test.go
+++ b/helper/init_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestUnit(t *testing.T) {
-	suite := spec.New("openliberty-helper", spec.Report(report.Terminal{}))
+	suite := spec.New("liberty-helper", spec.Report(report.Terminal{}))
 	suite("Link", testLink)
 	suite.Run(t)
 }

--- a/liberty/base.go
+++ b/liberty/base.go
@@ -85,6 +85,7 @@ func (b Base) Contribute(layer libcnb.Layer) (libcnb.Layer, error) {
 }
 
 func (b Base) contribute(layer libcnb.Layer) error {
+	layer.LaunchEnvironment.Default("BPI_LIBERTY_SERVER_NAME", b.ServerName)
 
 	serverBuildSource := core.NewServerBuildSource(b.ApplicationPath, b.ServerName, b.Logger)
 	isPackagedServer, err := serverBuildSource.Detect()

--- a/liberty/build.go
+++ b/liberty/build.go
@@ -133,6 +133,10 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	}
 	dc.Logger = b.Logger
 
+	h := libpak.NewHelperLayerContributor(context.Buildpack, "linker")
+	h.Logger = b.Logger
+	result.Layers = append(result.Layers, h)
+
 	if serverName == "" {
 		serverName, err = detectedBuildSrc.DefaultServerName()
 		if err != nil {

--- a/liberty/build_test.go
+++ b/liberty/build_test.go
@@ -94,9 +94,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(result.Layers).To(HaveLen(2))
-			Expect(result.Layers[0].Name()).To(Equal("base"))
-			Expect(result.Layers[1].Name()).To(Equal("open-liberty-runtime-full"))
+			Expect(result.Layers).To(HaveLen(3))
+			Expect(result.Layers[0].Name()).To(Equal("helper"))
+			Expect(result.Layers[1].Name()).To(Equal("base"))
+			Expect(result.Layers[2].Name()).To(Equal("open-liberty-runtime-full"))
 
 			sbomScanner.AssertCalled(t, "ScanLaunch", ctx.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON)
 		})
@@ -109,9 +110,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(result.Layers).To(HaveLen(2))
-			Expect(result.Layers[0].Name()).To(Equal("base"))
-			Expect(result.Layers[1].Name()).To(Equal("websphere-liberty-runtime-kernel"))
+			Expect(result.Layers).To(HaveLen(3))
+			Expect(result.Layers[0].Name()).To(Equal("helper"))
+			Expect(result.Layers[1].Name()).To(Equal("base"))
+			Expect(result.Layers[2].Name()).To(Equal("websphere-liberty-runtime-kernel"))
 
 			sbomScanner.AssertCalled(t, "ScanLaunch", ctx.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON)
 		})
@@ -124,9 +126,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(result.Layers).To(HaveLen(2))
-			Expect(result.Layers[0].Name()).To(Equal("base"))
-			Expect(result.Layers[1].Name()).To(Equal("open-liberty-runtime-jakartaee9"))
+			Expect(result.Layers).To(HaveLen(3))
+			Expect(result.Layers[0].Name()).To(Equal("helper"))
+			Expect(result.Layers[1].Name()).To(Equal("base"))
+			Expect(result.Layers[2].Name()).To(Equal("open-liberty-runtime-jakartaee9"))
 
 			sbomScanner.AssertCalled(t, "ScanLaunch", ctx.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON)
 		})
@@ -244,9 +247,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(result.Layers).To(HaveLen(2))
-			Expect(result.Layers[0].Name()).To(Equal("base"))
-			Expect(result.Layers[1].Name()).To(Equal("open-liberty-runtime-jakartaee9"))
+			Expect(result.Layers).To(HaveLen(3))
+			Expect(result.Layers[0].Name()).To(Equal("helper"))
+			Expect(result.Layers[1].Name()).To(Equal("base"))
+			Expect(result.Layers[2].Name()).To(Equal("open-liberty-runtime-jakartaee9"))
 
 			sbomScanner.AssertCalled(t, "ScanLaunch", ctx.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON)
 		})
@@ -280,9 +284,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}.Build(ctx)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Layers).To(HaveLen(2))
-			Expect(result.Layers[0].Name()).To(Equal("base"))
-			Expect(result.Layers[1].Name()).To(Equal("open-liberty-runtime-full"))
+			Expect(result.Layers).To(HaveLen(3))
+			Expect(result.Layers[0].Name()).To(Equal("helper"))
+			Expect(result.Layers[1].Name()).To(Equal("base"))
+			Expect(result.Layers[2].Name()).To(Equal("open-liberty-runtime-full"))
 			Expect(result.Unmet).To(HaveLen(0))
 
 			sbomScanner.AssertCalled(t, "ScanLaunch", filepath.Join(ctx.Application.Path, "usr", "servers", "defaultServer"), libcnb.SyftJSON, libcnb.CycloneDXJSON)
@@ -313,9 +318,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			}.Build(ctx)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Layers).To(HaveLen(2))
-			Expect(result.Layers[0].Name()).To(Equal("base"))
-			Expect(result.Layers[1].Name()).To(Equal("open-liberty-runtime-full"))
+			Expect(result.Layers).To(HaveLen(3))
+			Expect(result.Layers[0].Name()).To(Equal("helper"))
+			Expect(result.Layers[1].Name()).To(Equal("base"))
+			Expect(result.Layers[2].Name()).To(Equal("open-liberty-runtime-full"))
 			Expect(result.Unmet).To(HaveLen(0))
 
 			sbomScanner.AssertCalled(t, "ScanLaunch", ctx.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
When I re-added the helper in PR #200 to allow `server.xml` and `bootstrap.properties` to be provided via a binding, I missed adding the helper binary to the helper layer.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Re-add the helper process to allow config to be provided during runtime.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
