### PR TITLE
Enable verbose gc logging

### DIFF
--- a/internal/util/init_test.go
+++ b/internal/util/init_test.go
@@ -28,5 +28,6 @@ func TestUnit(t *testing.T) {
 	suite("App", testApp)
 	suite("Archive", testArchive)
 	suite("File", testFile)
+	suite("JVM", testJVM)
 	suite.Run(t)
 }

--- a/internal/util/jvm.go
+++ b/internal/util/jvm.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/paketo-buildpacks/libpak/effect"
+	"io"
+	"strings"
+)
+
+func DetectJVMName(executor effect.Executor) (string, error) {
+	pr, pw := io.Pipe()
+	defer pr.Close()
+	defer pw.Close()
+
+	resultCh := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(pr)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.Contains(line, "java.vm.name") {
+				if strings.Contains(line, "OpenJ9") {
+					resultCh <- "OpenJ9"
+				} else if strings.Contains(line, "OpenJDK") {
+					resultCh <- "OpenJDK"
+				} else {
+					resultCh <- ""
+				}
+				return
+			}
+		}
+		resultCh <- ""
+	}()
+
+	if err := executor.Execute(effect.Execution{
+		Command: "java",
+		Args:    []string{"-XshowSettings:properties", "-version"},
+		Stderr:  pw,
+	}); err != nil {
+		return "", fmt.Errorf("unable to detect JVM name")
+	}
+
+	pw.Close()
+	return <-resultCh, nil
+}

--- a/internal/util/jvm_test.go
+++ b/internal/util/jvm_test.go
@@ -37,7 +37,7 @@ func testJVM(t *testing.T, when spec.G, it spec.S) {
 			executor := &mocks.Executor{}
 			executor.On("Execute", mock.Anything).Run(func(args mock.Arguments) {
 				arg := args.Get(0).(effect.Execution)
-				_, err := arg.Stderr.Write([]byte(`
+				_, err := arg.Stdout.Write([]byte(`
 						java.vendor = IBM Corporation
 						java.vendor.url = https://www.ibm.com/semeru-runtimes
 						java.vendor.url.bug = https://github.com/ibmruntimes/Semeru-Runtimes/issues
@@ -57,7 +57,7 @@ func testJVM(t *testing.T, when spec.G, it spec.S) {
 			executor := &mocks.Executor{}
 			executor.On("Execute", mock.Anything).Run(func(args mock.Arguments) {
 				arg := args.Get(0).(effect.Execution)
-				_, err := arg.Stderr.Write([]byte(`
+				_, err := arg.Stdout.Write([]byte(`
 						java.vendor = BellSoft
 						java.vendor.url = https://bell-sw.com/
 						java.vendor.url.bug = https://bell-sw.com/support

--- a/internal/util/jvm_test.go
+++ b/internal/util/jvm_test.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package util_test
+
+import (
+	"github.com/paketo-buildpacks/liberty/internal/util"
+	"github.com/paketo-buildpacks/libpak/effect"
+	"github.com/paketo-buildpacks/libpak/effect/mocks"
+	"github.com/sclevine/spec"
+	"github.com/stretchr/testify/mock"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func testJVM(t *testing.T, when spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+	)
+
+	when("checking JVM name", func() {
+		it("detects the OpenJ9 JVM", func() {
+			executor := &mocks.Executor{}
+			executor.On("Execute", mock.Anything).Run(func(args mock.Arguments) {
+				arg := args.Get(0).(effect.Execution)
+				_, err := arg.Stderr.Write([]byte(`
+						java.vendor = IBM Corporation
+						java.vendor.url = https://www.ibm.com/semeru-runtimes
+						java.vendor.url.bug = https://github.com/ibmruntimes/Semeru-Runtimes/issues
+						java.vendor.version = 11.0.16.1
+						java.version = 11.0.16.1
+						java.version.date = 2022-08-12
+						java.vm.name = Eclipse OpenJ9 VM
+						java.vm.vendor = Eclipse OpenJ9
+						java.vm.version = openj9-0.33.1`),
+				)
+				Expect(err).ToNot(HaveOccurred())
+			}).Return(nil)
+			Expect(util.DetectJVMName(executor)).To(Equal("OpenJ9"))
+		})
+
+		it("detects the Bellsoft Liberica JVM", func() {
+			executor := &mocks.Executor{}
+			executor.On("Execute", mock.Anything).Run(func(args mock.Arguments) {
+				arg := args.Get(0).(effect.Execution)
+				_, err := arg.Stderr.Write([]byte(`
+						java.vendor = BellSoft
+						java.vendor.url = https://bell-sw.com/
+						java.vendor.url.bug = https://bell-sw.com/support
+						java.version = 11.0.16.1
+						java.version.date = 2022-08-12
+						java.vm.compressedOopsMode = 32-bit
+						java.vm.info = mixed mode
+						java.vm.name = OpenJDK 64-Bit Server VM
+						java.vm.vendor = BellSoft
+						java.vm.version = 11.0.16.1+1-LTS`),
+				)
+				Expect(err).ToNot(HaveOccurred())
+			}).Return(nil)
+			Expect(util.DetectJVMName(executor)).To(Equal("OpenJDK"))
+		})
+	})
+}

--- a/liberty/base_test.go
+++ b/liberty/base_test.go
@@ -94,6 +94,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			&liberty.FeatureDescriptor{},
 			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
+			"OpenJDK",
 		)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
@@ -125,6 +126,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			&liberty.FeatureDescriptor{},
 			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
+			"OpenJDK",
 		)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
@@ -157,6 +159,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			&liberty.FeatureDescriptor{},
 			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
+			"OpenJDK",
 		)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
@@ -199,6 +202,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			&liberty.FeatureDescriptor{},
 			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
+			"OpenJDK",
 		)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
@@ -235,6 +239,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			&liberty.FeatureDescriptor{},
 			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
+			"OpenJDK",
 		)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
@@ -263,6 +268,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			&liberty.FeatureDescriptor{},
 			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
+			"OpenJDK",
 		)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
@@ -291,6 +297,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			&liberty.FeatureDescriptor{},
 			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
+			"OpenJDK",
 		)
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
@@ -344,6 +351,7 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 			userFeatureDescriptor,
 			libcnb.Binding{},
 			bard.NewLogger(os.Stdout),
+			"OpenJDK",
 		)
 
 		layer, err = base.Contribute(layer)
@@ -354,5 +362,43 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 		Expect(filepath.Join(usrPath, "extension", "lib", "test.feature_1.0.0.jar")).To(BeARegularFile())
 		Expect(filepath.Join(usrPath, "extension", "lib", "features", "test.feature_1.0.0.mf")).To(BeARegularFile())
 		Expect(filepath.Join(usrPath, "servers", "defaultServer", "configDropins", "defaults", "features.xml")).To(BeARegularFile())
+	})
+
+	it("appends verbosegc to JAVA_TOOL_OPTIONS if the OpenJ9 JVM is provided", func() {
+		base := liberty.NewBase(
+			ctx.Application.Path,
+			ctx.Buildpack.Path,
+			"defaultServer",
+			[]string{"jsp-2.3"},
+			&liberty.FeatureDescriptor{},
+			libcnb.Binding{},
+			bard.NewLogger(os.Stdout),
+			"OpenJ9",
+		)
+		layer, err := ctx.Layers.Layer("test-layer")
+		Expect(err).NotTo(HaveOccurred())
+
+		layer, err = base.Contribute(layer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(layer.LaunchEnvironment["JAVA_TOOL_OPTIONS.append"]).To(Equal("-Xverbosegclog:verbosegc.%pid.%seq.log,5,10000"))
+	})
+
+	it("does not append verbosegc to JAVA_TOOL_OPTIONS if a non-OpenJ9 JVM is provided", func() {
+		base := liberty.NewBase(
+			ctx.Application.Path,
+			ctx.Buildpack.Path,
+			"defaultServer",
+			[]string{"jsp-2.3"},
+			&liberty.FeatureDescriptor{},
+			libcnb.Binding{},
+			bard.NewLogger(os.Stdout),
+			"OpenJDK",
+		)
+		layer, err := ctx.Layers.Layer("test-layer")
+		Expect(err).NotTo(HaveOccurred())
+
+		layer, err = base.Contribute(layer)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(layer.LaunchEnvironment["JAVA_TOOL_OPTIONS.append"]).To(BeEmpty())
 	})
 }

--- a/liberty/build.go
+++ b/liberty/build.go
@@ -19,6 +19,7 @@ package liberty
 import (
 	"fmt"
 	"github.com/heroku/color"
+	"github.com/paketo-buildpacks/liberty/internal/util"
 	"github.com/paketo-buildpacks/libpak/bindings"
 	sherpa "github.com/paketo-buildpacks/libpak/sherpa"
 	"strings"
@@ -190,6 +191,10 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	if err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve liberty bindings\n%w", err)
 	}
+	jvmName, err := util.DetectJVMName(b.Executor)
+	if err != nil {
+		return libcnb.BuildResult{}, err
+	}
 	base := NewBase(
 		context.Application.Path,
 		context.Buildpack.Path,
@@ -198,6 +203,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 		userFeatureDescriptor,
 		binding,
 		b.Logger,
+		jvmName,
 	)
 	result.Layers = append(result.Layers, base)
 

--- a/liberty/build_test.go
+++ b/liberty/build_test.go
@@ -18,6 +18,8 @@ package liberty_test
 
 import (
 	"bytes"
+	"github.com/paketo-buildpacks/libpak/effect"
+	"github.com/stretchr/testify/mock"
 	"io"
 	"io/ioutil"
 	"os"
@@ -28,6 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/paketo-buildpacks/liberty/liberty"
 	"github.com/paketo-buildpacks/libpak/bard"
+	effectMocks "github.com/paketo-buildpacks/libpak/effect/mocks"
 	"github.com/paketo-buildpacks/libpak/sbom/mocks"
 	"github.com/sclevine/spec"
 )
@@ -37,6 +40,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		Expect      = NewWithT(t).Expect
 		ctx         libcnb.BuildContext
 		sbomScanner mocks.SBOMScanner
+		executor    = &effectMocks.Executor{}
 	)
 
 	it.Before(func() {
@@ -70,6 +74,22 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		sbomScanner = mocks.SBOMScanner{}
 		sbomScanner.On("ScanLaunch", ctx.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON).Return(nil)
 		sbomScanner.On("ScanLaunch", filepath.Join(ctx.Application.Path, "usr", "servers", "defaultServer"), libcnb.SyftJSON, libcnb.CycloneDXJSON).Return(nil)
+
+		executor.On("Execute", mock.Anything).Run(func(args mock.Arguments) {
+			arg := args.Get(0).(effect.Execution)
+			_, err := arg.Stderr.Write([]byte(`
+						java.vendor = IBM Corporation
+						java.vendor.url = https://www.ibm.com/semeru-runtimes
+						java.vendor.url.bug = https://github.com/ibmruntimes/Semeru-Runtimes/issues
+						java.vendor.version = 11.0.16.1
+						java.version = 11.0.16.1
+						java.version.date = 2022-08-12
+						java.vm.name = Eclipse OpenJ9 VM
+						java.vm.vendor = Eclipse OpenJ9
+						java.vm.version = openj9-0.33.1`),
+			)
+			Expect(err).ToNot(HaveOccurred())
+		}).Return(nil)
 	})
 
 	it.After(func() {
@@ -91,6 +111,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			result, err := liberty.Build{
 				Logger:      bard.NewLogger(io.Discard),
 				SBOMScanner: &sbomScanner,
+				Executor:    executor,
 			}.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -107,6 +128,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			result, err := liberty.Build{
 				Logger:      bard.NewLogger(io.Discard),
 				SBOMScanner: &sbomScanner,
+				Executor:    executor,
 			}.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -123,6 +145,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			result, err := liberty.Build{
 				Logger:      bard.NewLogger(io.Discard),
 				SBOMScanner: &sbomScanner,
+				Executor:    executor,
 			}.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -150,6 +173,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			result, err := liberty.Build{
 				Logger:      bard.NewLogger(io.Discard),
 				SBOMScanner: &sbomScanner,
+				Executor:    executor,
 			}.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -169,6 +193,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		result, err := liberty.Build{
 			Logger:      bard.NewLogger(io.Discard),
 			SBOMScanner: &sbomScanner,
+			Executor:    executor,
 		}.Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -196,6 +221,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				result, err := liberty.Build{
 					Logger:      bard.NewLogger(buf),
 					SBOMScanner: &sbomScanner,
+					Executor:    executor,
 				}.Build(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -214,6 +240,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				result, err := liberty.Build{
 					Logger:      bard.NewLogger(buf),
 					SBOMScanner: &sbomScanner,
+					Executor:    executor,
 				}.Build(ctx)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -244,6 +271,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			result, err := liberty.Build{
 				Logger:      bard.NewLogger(io.Discard),
 				SBOMScanner: &sbomScanner,
+				Executor:    executor,
 			}.Build(ctx)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -281,6 +309,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			result, err := liberty.Build{
 				Logger:      bard.NewLogger(io.Discard),
 				SBOMScanner: &sbomScanner,
+				Executor:    executor,
 			}.Build(ctx)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -298,6 +327,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			result, err := liberty.Build{
 				Logger:      bard.NewLogger(io.Discard),
 				SBOMScanner: &sbomScanner,
+				Executor:    executor,
 			}.Build(ctx)
 
 			Expect(err).NotTo(HaveOccurred())
@@ -315,6 +345,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			result, err := liberty.Build{
 				Logger:      bard.NewLogger(io.Discard),
 				SBOMScanner: &sbomScanner,
+				Executor:    executor,
 			}.Build(ctx)
 
 			Expect(err).NotTo(HaveOccurred())

--- a/liberty/build_test.go
+++ b/liberty/build_test.go
@@ -77,7 +77,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		executor.On("Execute", mock.Anything).Run(func(args mock.Arguments) {
 			arg := args.Get(0).(effect.Execution)
-			_, err := arg.Stderr.Write([]byte(`
+			_, err := arg.Stdout.Write([]byte(`
 						java.vendor = IBM Corporation
 						java.vendor.url = https://www.ibm.com/semeru-runtimes
 						java.vendor.url.bug = https://github.com/ibmruntimes/Semeru-Runtimes/issues


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Enable verbose GC logging when using the OpenJ9 JVM.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Verbose GC logging has a very low overhead and is useful if there are any high heap issues. @kevin-ortega can provide more details on this feature if you have any questions.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
