### PR TITLE
Symlink app archive to apps instead of expanding

### DIFF
--- a/liberty/base.go
+++ b/liberty/base.go
@@ -273,7 +273,7 @@ func (b Base) contributeApp(layer libcnb.Layer, config server.Config) error {
 	serverPath := filepath.Join(layer.Path, "wlp", "usr", "servers", b.ServerName)
 
 	linkPath := filepath.Join(serverPath, "apps", "app")
-	if err := os.Remove(linkPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+	if err := os.RemoveAll(linkPath); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("unable to remove app\n%w", err)
 	}
 
@@ -291,9 +291,11 @@ func (b Base) contributeApp(layer libcnb.Layer, config server.Config) error {
 		if err != nil {
 			return fmt.Errorf("unable to open compiled artifact\n%w", err)
 		}
-		err = crush.Extract(compiledArtifact, linkPath, 0)
-		if err != nil {
+		if err := crush.Extract(compiledArtifact, linkPath, 0); err != nil {
 			return fmt.Errorf("unable to extract compiled artifact\n%w", err)
+		}
+		if err := os.Remove(appPath); err != nil {
+			return fmt.Errorf("unable to remove compiled artifact\n%w", err)
 		}
 	}
 

--- a/liberty/base_test.go
+++ b/liberty/base_test.go
@@ -210,8 +210,10 @@ func testBase(t *testing.T, _ spec.G, it spec.S) {
 		layer, err = base.Contribute(layer)
 		Expect(err).ToNot(HaveOccurred())
 
+		// Ensure app war is expanded to <server>/apps/app and compiled artifact was deleted
 		Expect(filepath.Join(layer.Path, "wlp", "usr", "servers", "defaultServer", "apps", "app")).To(BeADirectory())
 		Expect(filepath.Join(layer.Path, "wlp", "usr", "servers", "defaultServer", "apps", "app", "index.html")).To(BeAnExistingFile())
+		Expect(filepath.Join(ctx.Application.Path, "test.war")).ToNot(BeAnExistingFile())
 
 		serverDir := filepath.Join(layer.Path, "wlp", "usr", "servers", "defaultServer")
 		for _, file := range []string{


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Skip expanding app archive and just symlink it to reduce image size.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Decreases image size to reduce costs to store, transfer, etc. the image.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
