### PR TITLE
Build server and app shared class cache

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -93,6 +93,34 @@ api = "0.7"
     launch = false
     name = "BP_LIBERTY_FEATURE_INSTALL_DISABLED"
 
+  [[metadata.configurations]]
+    build = true
+    default = "false"
+    description = "OpenJ9 only: Disable building the shared class cache."
+    launch = false
+    name = "BP_LIBERTY_SCC_DISABLED"
+
+  [[metadata.configurations]]
+    build = true
+    default = "100"
+    description = "OpenJ9 only: Size to use for the shared class cache."
+    launch = false
+    name = "BP_LIBERTY_SCC_SIZE_MB"
+
+  [[metadata.configurations]]
+    build = true
+    default = "1"
+    description = "OpenJ9 only: Number of iterations to cycle the server when building the shared class cache."
+    launch = false
+    name = "BP_LIBERTY_SCC_NUM_ITERATIONS"
+
+  [[metadata.configurations]]
+    build = true
+    default = "false"
+    description = "OpenJ9 only: Disable trimming the size of the shared class cache."
+    launch = false
+    name = "BP_LIBERTY_SCC_TRIM_SIZE_DISABLED"
+
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:ibm:open_liberty:23.0.0.2:*:*:*:*:*:*:*"]
     id = "open-liberty-runtime-full"

--- a/internal/util/jvm.go
+++ b/internal/util/jvm.go
@@ -19,11 +19,18 @@ package util
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
+	"github.com/paketo-buildpacks/libpak/bard"
 	"github.com/paketo-buildpacks/libpak/effect"
+	"io"
+	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 )
 
+// DetectJVMName returns the value for java.vm.name.
 func DetectJVMName(executor effect.Executor) (string, error) {
 	buf := &bytes.Buffer{}
 
@@ -47,5 +54,118 @@ func DetectJVMName(executor effect.Executor) (string, error) {
 			break
 		}
 	}
+
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("unable to read cache ratio\n%w", err)
+	}
+
 	return "", nil
+}
+
+type SharedClassCache struct {
+	Name string
+	Path string
+
+	Executor effect.Executor
+	Logger   bard.Logger
+}
+
+type SharedClassCacheOptions struct {
+	Enabled       bool
+	SizeMB        int
+	NumIterations int
+	Trim          bool
+}
+
+func (scc SharedClassCache) GetFillRatio() (float64, error) {
+	sccOption := fmt.Sprintf("-Xshareclasses:name=%s,cacheDir=%s,printTopLayerStats", scc.Name, scc.Path)
+	args := []string{sccOption, "-version"}
+	buf := &bytes.Buffer{}
+	stderrBuf := &bytes.Buffer{}
+	err := scc.Executor.Execute(effect.Execution{
+		Command: "java",
+		Args:    args,
+		Stdout:  buf,
+		Stderr:  stderrBuf,
+	})
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) && exitError.ExitCode() != 1 {
+		return 0.0, fmt.Errorf("unable to get cache stats\n%w\n%s", err, stderrBuf.String())
+	}
+
+	r, err := regexp.Compile(`Cache is (\d+)% full`)
+	if err != nil {
+		return 0.0, err
+	}
+
+	scanner := bufio.NewScanner(buf)
+	for scanner.Scan() {
+		line := scanner.Text()
+		scc.Logger.Debugf("%s\n", line)
+		if matches := r.FindStringSubmatch(line); matches != nil {
+			v, err := strconv.ParseInt(matches[1], 10, 64)
+			if err != nil {
+				return 0.0, err
+			}
+			return float64(v) / 100, nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return 0.0, fmt.Errorf("unable to read cache ratio\n%w", err)
+	}
+
+	return 0.0, fmt.Errorf("unable to find cache fill ratio")
+}
+
+func (scc SharedClassCache) CreateLayer(size int) error {
+	scc.Logger.Bodyf("Creating SCC layer with size %dm", size)
+	return scc.execSccCommand("createLayer,groupAccess", fmt.Sprintf("-Xscmx%dm", size))
+}
+
+func (scc SharedClassCache) Resize(size int) error {
+	fillRatio, err := scc.GetFillRatio()
+	if err != nil {
+		return err
+	}
+	newSize := int(float64(size)*fillRatio + 0.5)
+	scc.Logger.Bodyf("Resizing cache from %dm to %dm", size, newSize)
+	if err := scc.Delete(); err != nil {
+		return err
+	}
+	if err := scc.CreateLayer(newSize); err != nil {
+		return fmt.Errorf("unable to create resized layer\n%w", err)
+	}
+	return nil
+}
+
+func (scc SharedClassCache) Delete() error {
+	err := scc.execSccCommand("destroy")
+	var exitError *exec.ExitError
+	if errors.As(err, &exitError) && exitError.ExitCode() == 1 {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("unable to destroy cache\n%w", err)
+	}
+	return nil
+}
+
+func (scc SharedClassCache) execSccCommand(command string, options ...string) error {
+	sccOption := fmt.Sprintf("-Xshareclasses:name=%s,cacheDir=%s,%s", scc.Name, scc.Path, command)
+	writer := io.Discard
+	if scc.Logger.IsDebugEnabled() {
+		sccOption = fmt.Sprintf("%s,verbose", sccOption)
+		writer = scc.Logger.InfoWriter()
+	}
+	args := []string{sccOption}
+	if options != nil {
+		args = append(args, options...)
+	}
+	return scc.Executor.Execute(effect.Execution{
+		Command: "java",
+		Args:    append(args, "-version"),
+		Stdout:  writer,
+		Stderr:  writer,
+	})
 }

--- a/internal/util/jvm.go
+++ b/internal/util/jvm.go
@@ -56,7 +56,7 @@ func DetectJVMName(executor effect.Executor) (string, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("unable to read cache ratio\n%w", err)
+		return "", fmt.Errorf("unable to read JVM name\n%w", err)
 	}
 
 	return "", nil
@@ -93,10 +93,7 @@ func (scc SharedClassCache) GetFillRatio() (float64, error) {
 		return 0.0, fmt.Errorf("unable to get cache stats\n%w\n%s", err, stderrBuf.String())
 	}
 
-	r, err := regexp.Compile(`Cache is (\d+)% full`)
-	if err != nil {
-		return 0.0, err
-	}
+	r := regexp.MustCompile(`Cache is (\d+)% full`)
 
 	scanner := bufio.NewScanner(buf)
 	for scanner.Scan() {
@@ -105,7 +102,7 @@ func (scc SharedClassCache) GetFillRatio() (float64, error) {
 		if matches := r.FindStringSubmatch(line); matches != nil {
 			v, err := strconv.ParseInt(matches[1], 10, 64)
 			if err != nil {
-				return 0.0, err
+				return 0.0, fmt.Errorf("unable to parse [%s] to int\n%w", matches[1], err)
 			}
 			return float64(v) / 100, nil
 		}

--- a/liberty/build_test.go
+++ b/liberty/build_test.go
@@ -55,6 +55,10 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				{"name": "BP_LIBERTY_PROFILE", "default": "", "build": true},
 				{"name": "BP_LIBERTY_INSTALL_TYPE", "default": "ol", "build": true},
 				{"name": "BP_LIBERTY_SERVER_NAME", "default": "", "build": true},
+				{"name": "BP_LIBERTY_SCC_DISABLED", "default": "false", "build": true},
+				{"name": "BP_LIBERTY_SCC_SIZE_MB", "default": "100", "build": true},
+				{"name": "BP_LIBERTY_SCC_NUM_ITERATIONS", "default": "1", "build": true},
+				{"name": "BP_LIBERTY_SCC_TRIM_SIZE_DISABLED", "default": "false", "build": true},
 			},
 			"dependencies": []map[string]interface{}{
 				{"id": "open-liberty-runtime-kernel", "version": "21.0.11"},

--- a/liberty/distribution_test.go
+++ b/liberty/distribution_test.go
@@ -17,6 +17,7 @@
 package liberty_test
 
 import (
+	"github.com/paketo-buildpacks/liberty/internal/util"
 	"io"
 	"io/ioutil"
 	"os"
@@ -67,7 +68,7 @@ func testDistribution(t *testing.T, when spec.G, it spec.S) {
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
 
-		distro := liberty.NewDistribution(dep, dc, "ol", "defaultServer", ctx.Application.Path, false, []string{}, []string{}, executor)
+		distro := liberty.NewDistribution(dep, dc, "ol", "defaultServer", ctx.Application.Path, false, []string{}, []string{}, util.SharedClassCacheOptions{}, executor)
 		distro.Logger = bard.NewLogger(io.Discard)
 
 		Expect(distro.LayerContributor.ExpectedMetadata.(map[string]interface{})).To(HaveKeyWithValue("dependency", dep))
@@ -101,7 +102,7 @@ func testDistribution(t *testing.T, when spec.G, it spec.S) {
 		layer, err := ctx.Layers.Layer("test-layer")
 		Expect(err).NotTo(HaveOccurred())
 
-		distro := liberty.NewDistribution(dep, dc, "ol", "defaultServer", ctx.Application.Path, false, []string{}, []string{iFixPath}, executor)
+		distro := liberty.NewDistribution(dep, dc, "ol", "defaultServer", ctx.Application.Path, false, []string{}, []string{iFixPath}, util.SharedClassCacheOptions{}, executor)
 		distro.Logger = bard.NewLogger(io.Discard)
 
 		Expect(distro.LayerContributor.ExpectedMetadata.(map[string]interface{})).To(HaveKeyWithValue("dependency", dep))
@@ -136,7 +137,7 @@ func testDistribution(t *testing.T, when spec.G, it spec.S) {
 		executor.On("Execute", mock.Anything).Return(nil)
 
 		features := []string{"foo", "bar", "baz"}
-		distro := liberty.NewDistribution(dep, dc, "ol", "defaultServer", ctx.Application.Path, false, features, []string{}, executor)
+		distro := liberty.NewDistribution(dep, dc, "ol", "defaultServer", ctx.Application.Path, false, features, []string{}, util.SharedClassCacheOptions{}, executor)
 		distro.Logger = bard.NewLogger(io.Discard)
 
 		Expect(distro.LayerContributor.ExpectedMetadata.(map[string]interface{})).To(HaveKeyWithValue("dependency", dep))
@@ -167,7 +168,7 @@ func testDistribution(t *testing.T, when spec.G, it spec.S) {
 		executor.On("Execute", mock.Anything).Return(nil)
 
 		features := []string{"foo", "bar", "baz"}
-		distro := liberty.NewDistribution(dep, dc, "ol", "defaultServer", ctx.Application.Path, true, features, []string{}, executor)
+		distro := liberty.NewDistribution(dep, dc, "ol", "defaultServer", ctx.Application.Path, true, features, []string{}, util.SharedClassCacheOptions{}, executor)
 		distro.Logger = bard.NewLogger(io.Discard)
 
 		Expect(distro.LayerContributor.ExpectedMetadata.(map[string]interface{})).To(HaveKeyWithValue("features", features))


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This change builds a shared class cache (SCC) for Liberty during the build to improve app startup times. The following build config options were added:

* `BP_LIBERTY_SCC_DISABLED` disables the SCC from being built (default: false)
* `BP_LIBERTY_SCC_SIZE_MB` controls the size of the initial SCC (default: 100mb)
* `BP_LIBERTY_SCC_NUM_ITERATIONS` controls the number of times the server is started/stopped when building the SCC
* `BP_LIBERTY_SCC_TRIM_SIZE_DISABLED` controls whether the SCC's size is trimmed in the end.

## Use Cases


## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
