### PR TITLE
Fix codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @paketo-buildpacks/java-maintainers
-* @paketo-buildpacks/java-liberty
+* @paketo-buildpacks/java-maintainers @paketo-buildpacks/java-liberty

--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -4,9 +4,7 @@ github:
 
 codeowners:
 - path:  "*"
-  owner: "@paketo-buildpacks/java-maintainers"
-- path: "*"
-  owner: "@paketo-buildpacks/java-liberty"
+  owner: "@paketo-buildpacks/java-maintainers @paketo-buildpacks/java-liberty"
 
 package:
   repositories:   ["docker.io/paketobuildpacks/liberty","gcr.io/paketo-buildpacks/liberty"]


### PR DESCRIPTION
Previously this was requiring review from both groups instead of one from either group. This should adjust things so that only one review from either group is required.
