### PR TITLE
Update Open Liberty license to EPL-2.0

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -132,7 +132,7 @@ api = "0.7"
     version = "23.0.3"
 
     [[metadata.dependencies.licenses]]
-      type = "EPL-1.0"
+      type = "EPL-2.0"
       uri = "https://raw.githubusercontent.com/OpenLiberty/open-liberty/integration/LICENSE"
 
   [[metadata.dependencies]]
@@ -146,7 +146,7 @@ api = "0.7"
     version = "23.0.3"
 
     [[metadata.dependencies.licenses]]
-      type = "EPL-1.0"
+      type = "EPL-2.0"
       uri = "https://raw.githubusercontent.com/OpenLiberty/open-liberty/integration/LICENSE"
 
   [[metadata.dependencies]]
@@ -160,7 +160,7 @@ api = "0.7"
     version = "23.0.3"
 
     [[metadata.dependencies.licenses]]
-      type = "EPL-1.0"
+      type = "EPL-2.0"
       uri = "https://raw.githubusercontent.com/OpenLiberty/open-liberty/integration/LICENSE"
 
   [[metadata.dependencies]]
@@ -174,7 +174,7 @@ api = "0.7"
     version = "23.0.3"
 
     [[metadata.dependencies.licenses]]
-      type = "EPL-1.0"
+      type = "EPL-2.0"
       uri = "https://raw.githubusercontent.com/OpenLiberty/open-liberty/integration/LICENSE"
 
   [[metadata.dependencies]]
@@ -188,7 +188,7 @@ api = "0.7"
     version = "23.0.3"
 
     [[metadata.dependencies.licenses]]
-      type = "EPL-1.0"
+      type = "EPL-2.0"
       uri = "https://raw.githubusercontent.com/OpenLiberty/open-liberty/integration/LICENSE"
 
   [[metadata.dependencies]]
@@ -202,7 +202,7 @@ api = "0.7"
     version = "23.0.3"
 
     [[metadata.dependencies.licenses]]
-      type = "EPL-1.0"
+      type = "EPL-2.0"
       uri = "https://raw.githubusercontent.com/OpenLiberty/open-liberty/integration/LICENSE"
 
   [[metadata.dependencies]]
@@ -216,7 +216,7 @@ api = "0.7"
     version = "23.0.3"
 
     [[metadata.dependencies.licenses]]
-      type = "EPL-1.0"
+      type = "EPL-2.0"
       uri = "https://raw.githubusercontent.com/OpenLiberty/open-liberty/integration/LICENSE"
 
   [[metadata.dependencies]]
@@ -230,7 +230,7 @@ api = "0.7"
     version = "23.0.3"
 
     [[metadata.dependencies.licenses]]
-      type = "EPL-1.0"
+      type = "EPL-2.0"
       uri = "https://raw.githubusercontent.com/OpenLiberty/open-liberty/integration/LICENSE"
 
   [[metadata.dependencies]]


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Open Liberty was [re-licensed](https://openliberty.io/blog/2023/02/07/23.0.0.1.html).   This PR simply updates the license type for the buildpack's Open Liberty dependencies.

## Use Cases
<!-- An explanation of the use cases your change enables -->
none
## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
