### PR TITLE
Add detection logging messages at info level

### DIFF
--- a/internal/core/buildsrc.go
+++ b/internal/core/buildsrc.go
@@ -74,7 +74,7 @@ func (a AppBuildSource) Name() string {
 func (a AppBuildSource) Detect() (bool, error) {
 	// If user requests an app server, and it is not `liberty` then skip
 	if a.RequestedAppServer != "" && a.RequestedAppServer != JavaAppServerLiberty {
-		a.Logger.Debugf("failed to match requested app server of [%s], buildpack supports [%s]", a.RequestedAppServer, JavaAppServerLiberty)
+		a.Logger.Infof("SKIPPED: failed to match requested app server of [%s], buildpack supports [%s]", a.RequestedAppServer, JavaAppServerLiberty)
 		return false, nil
 	}
 
@@ -84,7 +84,7 @@ func (a AppBuildSource) Detect() (bool, error) {
 		return false, err
 	}
 	if isMainClassDefined {
-		a.Logger.Debug("`Main-Class` found in `META-INF/MANIFEST.MF`, skipping build")
+		a.Logger.Info("SKIPPED: `Main-Class` found in `META-INF/MANIFEST.MF`, skipping build")
 		return false, nil
 	}
 


### PR DESCRIPTION
*Log messages were checked during testing*

```
=== RUN   TestUnit/liberty/Detect/fails_if_a_Main-Class_is_present
SKIPPED: Detected build source is null
```


## Summary
This PR adds additional logging when Detect returns false for this buildpack. This is to provide more information about why the detection failed for this buildpack when verbose/debug logging is enabled. 

As of lifecycle v1.16.0, if the detect phase fails as a whole, log messages are printed at info level by default, without the need for the verbose flag.

## Use Cases
A `pack build` command with the `--verbose` flag set will show these log statement if detection fails. If Detect succeeds, the output is not shown unless `--verbose` is set.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
