### PR TITLE
Do not use effect.NewExecutor use CommandExecutor instead

### DIFF
--- a/helper/linker_test.go
+++ b/helper/linker_test.go
@@ -17,7 +17,6 @@
 package helper_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,12 +39,12 @@ func testLink(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		appDir, err = ioutil.TempDir("", "execd-helper-apps")
+		appDir, err = os.MkdirTemp("", "execd-helper-apps")
 		Expect(err).NotTo(HaveOccurred())
 		appDir, err = filepath.EvalSymlinks(appDir)
 		Expect(err).ToNot(HaveOccurred())
 
-		layerDir, err = ioutil.TempDir("", "execd-helper-layers")
+		layerDir, err = os.MkdirTemp("", "execd-helper-layers")
 		Expect(err).NotTo(HaveOccurred())
 		layerDir, err = filepath.EvalSymlinks(layerDir)
 		Expect(err).ToNot(HaveOccurred())

--- a/internal/core/buildsrc_test.go
+++ b/internal/core/buildsrc_test.go
@@ -17,7 +17,7 @@
 package core_test
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +37,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		testPath, err = ioutil.TempDir("", "core")
+		testPath, err = os.MkdirTemp("", "core")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -55,14 +55,14 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 			Expect(os.WriteFile(filepath.Join(testPath, "META-INF", "MANIFEST.MF"),
 				[]byte("Main-Class: com.java.HelloWorld"),
 				0644)).To(Succeed())
-			appBuildSource := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(ioutil.Discard))
+			appBuildSource := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(io.Discard))
 			ok, err := appBuildSource.Detect()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ok).To(BeFalse())
 		})
 
 		it("detects successfully when Main-Class is not set", func() {
-			appBuildSrc := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(ioutil.Discard))
+			appBuildSrc := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(io.Discard))
 			ok, err := appBuildSrc.Detect()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ok).To(BeTrue())
@@ -70,7 +70,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 
 		it("validates successfully when a compiled web archive is supplied", func() {
 			Expect(os.Mkdir(filepath.Join(testPath, "WEB-INF"), 0755)).To(Succeed())
-			appBuildSrc := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(ioutil.Discard))
+			appBuildSrc := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(io.Discard))
 			ok, err := appBuildSrc.ValidateApp()
 			Expect(err).To(Succeed())
 			Expect(ok).To(BeTrue())
@@ -79,21 +79,21 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 		it("validates successfully when a compiled enterprise archive is supplied", func() {
 			Expect(os.Mkdir(filepath.Join(testPath, "META-INF"), 0755)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(testPath, "META-INF", "application.xml"), []byte{}, 0644)).To(Succeed())
-			appBuildSrc := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(ioutil.Discard))
+			appBuildSrc := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(io.Discard))
 			ok, err := appBuildSrc.ValidateApp()
 			Expect(err).To(Succeed())
 			Expect(ok).To(BeTrue())
 		})
 
 		it("fails app validation when META-INF or application.xml not found", func() {
-			appBuildSrc := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(ioutil.Discard))
+			appBuildSrc := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(io.Discard))
 			ok, err := appBuildSrc.ValidateApp()
 			Expect(err).To(Succeed())
 			Expect(ok).To(BeFalse())
 		})
 
 		it("fails app validation when requested server is unknown", func() {
-			appBuildSrc := core.NewAppBuildSource(testPath, "foo", bard.NewLogger(ioutil.Discard))
+			appBuildSrc := core.NewAppBuildSource(testPath, "foo", bard.NewLogger(io.Discard))
 			ok, err := appBuildSrc.ValidateApp()
 			Expect(err).To(Succeed())
 			Expect(ok).To(BeFalse())
@@ -117,7 +117,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 				defaultServerPath := filepath.Join(serversPath, "defaultServer")
 				Expect(os.Mkdir(defaultServerPath, 0755)).To(Succeed())
 				Expect(os.WriteFile(filepath.Join(defaultServerPath, "server.xml"), []byte{}, 0644)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.Detect()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
@@ -127,7 +127,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 				testServerPath := filepath.Join(serversPath, "testServer")
 				Expect(os.Mkdir(testServerPath, 0755)).To(Succeed())
 				Expect(os.WriteFile(filepath.Join(testServerPath, "server.xml"), []byte{}, 0644)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.Detect()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
@@ -137,7 +137,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 				testServerPath := filepath.Join(serversPath, "testServer")
 				Expect(os.Mkdir(testServerPath, 0755)).To(Succeed())
 				Expect(os.WriteFile(filepath.Join(testServerPath, "server.xml"), []byte{}, 0644)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "testServer", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "testServer", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.Detect()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
@@ -148,7 +148,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 				Expect(os.Mkdir(testServerPath, 0755)).To(Succeed())
 				Expect(os.Mkdir(testServerPath+"-other", 0755)).To(Succeed())
 				Expect(os.WriteFile(filepath.Join(testServerPath, "server.xml"), []byte{}, 0644)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "testServer", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "testServer", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.Detect()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
@@ -159,13 +159,13 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 				Expect(os.Mkdir(testServerPath, 0755)).To(Succeed())
 				Expect(os.Mkdir(testServerPath+"-other", 0755)).To(Succeed())
 				Expect(os.WriteFile(filepath.Join(testServerPath, "server.xml"), []byte{}, 0644)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				_, err := serverBuildSource.Detect()
 				Expect(err).To(HaveOccurred())
 			})
 
 			it("fails to detect if there are no servers", func() {
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				_, err := serverBuildSource.Detect()
 				Expect(err).To(HaveOccurred())
 			})
@@ -173,7 +173,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 			it("validates enterprise archive is provided in apps", func() {
 				appPath := filepath.Join(serversPath, "testServer", "apps", "test.ear")
 				Expect(os.MkdirAll(appPath, 0755)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.ValidateApp()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
@@ -182,7 +182,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 			it("validates enterprise archive is provided in dropins", func() {
 				appPath := filepath.Join(serversPath, "testServer", "dropins", "test.ear")
 				Expect(os.MkdirAll(appPath, 0755)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.ValidateApp()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
@@ -191,7 +191,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 			it("validates web archive is provided in apps", func() {
 				appPath := filepath.Join(serversPath, "testServer", "apps", "test.war")
 				Expect(os.MkdirAll(appPath, 0755)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.ValidateApp()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
@@ -200,14 +200,14 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 			it("validates web archive is provided in dropins", func() {
 				appPath := filepath.Join(serversPath, "testServer", "dropins", "test.war")
 				Expect(os.MkdirAll(appPath, 0755)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.ValidateApp()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
 
 			it("does not validate when an app is not provided", func() {
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				_, err := serverBuildSource.ValidateApp()
 				Expect(err).To(HaveOccurred())
 			})
@@ -229,7 +229,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 				defaultServerPath := filepath.Join(serversPath, "defaultServer")
 				Expect(os.Mkdir(defaultServerPath, 0755)).To(Succeed())
 				Expect(os.WriteFile(filepath.Join(defaultServerPath, "server.xml"), []byte{}, 0644)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.Detect()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
@@ -239,7 +239,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 				testServerPath := filepath.Join(serversPath, "testServer")
 				Expect(os.Mkdir(testServerPath, 0755)).To(Succeed())
 				Expect(os.WriteFile(filepath.Join(testServerPath, "server.xml"), []byte{}, 0644)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.Detect()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
@@ -249,7 +249,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 				testServerPath := filepath.Join(serversPath, "testServer")
 				Expect(os.Mkdir(testServerPath, 0755)).To(Succeed())
 				Expect(os.WriteFile(filepath.Join(testServerPath, "server.xml"), []byte{}, 0644)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "testServer", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "testServer", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.Detect()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
@@ -260,7 +260,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 				Expect(os.Mkdir(testServerPath, 0755)).To(Succeed())
 				Expect(os.Mkdir(testServerPath+"-other", 0755)).To(Succeed())
 				Expect(os.WriteFile(filepath.Join(testServerPath, "server.xml"), []byte{}, 0644)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "testServer", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "testServer", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.Detect()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
@@ -271,13 +271,13 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 				Expect(os.Mkdir(testServerPath, 0755)).To(Succeed())
 				Expect(os.Mkdir(testServerPath+"-other", 0755)).To(Succeed())
 				Expect(os.WriteFile(filepath.Join(testServerPath, "server.xml"), []byte{}, 0644)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				_, err := serverBuildSource.Detect()
 				Expect(err).To(HaveOccurred())
 			})
 
 			it("fails to detect if there are no servers", func() {
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				_, err := serverBuildSource.Detect()
 				Expect(err).To(HaveOccurred())
 			})
@@ -285,7 +285,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 			it("validates enterprise archive is provided in dropins", func() {
 				appPath := filepath.Join(serversPath, "testServer", "dropins", "test.ear")
 				Expect(os.MkdirAll(appPath, 0755)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.ValidateApp()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
@@ -294,7 +294,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 			it("validates web archive is provided in apps", func() {
 				appPath := filepath.Join(serversPath, "testServer", "apps", "test.war")
 				Expect(os.MkdirAll(appPath, 0755)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.ValidateApp()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
@@ -303,14 +303,14 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 			it("validates web archive is provided in dropins", func() {
 				appPath := filepath.Join(serversPath, "testServer", "dropins", "test.war")
 				Expect(os.MkdirAll(appPath, 0755)).To(Succeed())
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				ok, err := serverBuildSource.ValidateApp()
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ok).To(BeTrue())
 			})
 
 			it("does not validate when an app is not provided", func() {
-				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(ioutil.Discard))
+				serverBuildSource := core.NewServerBuildSource(testPath, "", bard.NewLogger(io.Discard))
 				_, err := serverBuildSource.ValidateApp()
 				Expect(err).To(HaveOccurred())
 			})
@@ -320,7 +320,7 @@ func testBuildSource(t *testing.T, when spec.G, it spec.S) {
 	when("building an app source with server config", func() {
 		it("works", func() {
 			Expect(os.WriteFile(filepath.Join(testPath, "test.war"), []byte{}, 0644)).To(Succeed())
-			appBuildSource := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(ioutil.Discard))
+			appBuildSource := core.NewAppBuildSource(testPath, "liberty", bard.NewLogger(io.Discard))
 			ok, err := appBuildSource.Detect()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ok).To(BeTrue())

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,17 +21,18 @@ import (
 	"bytes"
 	"encoding/xml"
 	"fmt"
-	"github.com/antchfx/xmlquery"
-	"github.com/paketo-buildpacks/liberty/internal/util"
-	"github.com/paketo-buildpacks/libpak/bard"
-	"github.com/paketo-buildpacks/libpak/effect"
-	"github.com/paketo-buildpacks/libpak/sherpa"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/antchfx/xmlquery"
+	"github.com/paketo-buildpacks/liberty/internal/util"
+	"github.com/paketo-buildpacks/libpak/bard"
+	"github.com/paketo-buildpacks/libpak/effect"
+	"github.com/paketo-buildpacks/libpak/sherpa"
 )
 
 func GetServerConfigPath(serverPath string) string {
@@ -189,7 +190,7 @@ func GetServerList(userPath string) ([]string, error) {
 		return []string{}, nil
 	}
 
-	serverDirs, err := ioutil.ReadDir(serversPath)
+	serverDirs, err := os.ReadDir(serversPath)
 	if err != nil {
 		return []string{}, err
 	}
@@ -409,7 +410,7 @@ func ReadServerConfig(configPath string) (Config, error) {
 	}
 	defer xmlFile.Close()
 
-	content, err := ioutil.ReadAll(xmlFile)
+	content, err := io.ReadAll(xmlFile)
 	if err != nil {
 		return Config{}, fmt.Errorf("unable to read config '%s'\n%w", configPath, err)
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -18,7 +18,6 @@ package server_test
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -42,7 +41,7 @@ func testServer(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		testPath, err = ioutil.TempDir("", "server")
+		testPath, err = os.MkdirTemp("", "server")
 		Expect(err).NotTo(HaveOccurred())
 
 		// EvalSymlinks on macOS resolves the temporary directory too so do that here or checking the symlinks will fail
@@ -170,11 +169,11 @@ func testServer(t *testing.T, when spec.G, it spec.S) {
 
 		it("loads iFixes", func() {
 			Expect(os.MkdirAll(iFixesPath, 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(iFixesPath, "fix-1.jar"), []byte{}, 0644)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(iFixesPath, "fix-2.jar"), []byte{}, 0644)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(iFixesPath, ".DS_Store"), []byte{}, 0644)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(iFixesPath, "foo.txt"), []byte{}, 0644)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(iFixesPath, "fix-3.jar"), []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(iFixesPath, "fix-1.jar"), []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(iFixesPath, "fix-2.jar"), []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(iFixesPath, ".DS_Store"), []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(iFixesPath, "foo.txt"), []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(iFixesPath, "fix-3.jar"), []byte{}, 0644)).To(Succeed())
 
 			fixes, err := server.LoadIFixesList(iFixesPath)
 

--- a/internal/util/app.go
+++ b/internal/util/app.go
@@ -18,11 +18,12 @@ package util
 
 import (
 	"fmt"
-	"github.com/paketo-buildpacks/libjvm"
-	"github.com/paketo-buildpacks/libpak/sherpa"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/paketo-buildpacks/libjvm"
+	"github.com/paketo-buildpacks/libpak/sherpa"
 )
 
 // IsJvmApplicationPackage will return true if `META-INF/application.xml` or `WEB-INF/` exists, which happens when a
@@ -68,7 +69,7 @@ func GetApps(path string) ([]string, error) {
 		return []string{}, nil
 	}
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return []string{}, err
 	}

--- a/internal/util/app_test.go
+++ b/internal/util/app_test.go
@@ -17,12 +17,12 @@
 package util_test
 
 import (
-	"github.com/paketo-buildpacks/liberty/internal/util"
-	"github.com/sclevine/spec"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/paketo-buildpacks/liberty/internal/util"
+	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
 )
@@ -35,7 +35,7 @@ func testApp(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		testPath, err = ioutil.TempDir("", "app-utils")
+		testPath, err = os.MkdirTemp("", "app-utils")
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/internal/util/archive_test.go
+++ b/internal/util/archive_test.go
@@ -17,12 +17,12 @@
 package util_test
 
 import (
-	"github.com/paketo-buildpacks/liberty/internal/util"
-	"github.com/sclevine/spec"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/paketo-buildpacks/liberty/internal/util"
+	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
 )
@@ -35,7 +35,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		testPath, err = ioutil.TempDir("", "archive-utils")
+		testPath, err = os.MkdirTemp("", "archive-utils")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -53,7 +53,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 
 			testFile := filepath.Join(testPath, "test-dir", "test.txt")
 			Expect(testFile).To(BeARegularFile())
-			contents, err := ioutil.ReadFile(testFile)
+			contents, err := os.ReadFile(testFile)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(contents).To(Equal([]byte("foo bar baz\n")))
 		})
@@ -67,7 +67,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 
 			testFile := filepath.Join(testPath, "test.txt")
 			Expect(testFile).To(BeARegularFile())
-			contents, err := ioutil.ReadFile(testFile)
+			contents, err := os.ReadFile(testFile)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(contents).To(Equal([]byte("foo bar baz\n")))
 		})
@@ -83,7 +83,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 
 			testFile := filepath.Join(testPath, "test-dir", "test.txt")
 			Expect(testFile).To(BeARegularFile())
-			contents, err := ioutil.ReadFile(testFile)
+			contents, err := os.ReadFile(testFile)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(contents).To(Equal([]byte("foo bar baz\n")))
 		})
@@ -97,7 +97,7 @@ func testArchive(t *testing.T, when spec.G, it spec.S) {
 
 			testFile := filepath.Join(testPath, "test.txt")
 			Expect(testFile).To(BeARegularFile())
-			contents, err := ioutil.ReadFile(testFile)
+			contents, err := os.ReadFile(testFile)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(contents).To(Equal([]byte("foo bar baz\n")))
 		})

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -18,13 +18,13 @@ package util_test
 
 import (
 	"errors"
-	"github.com/paketo-buildpacks/liberty/internal/util"
-	"github.com/sclevine/spec"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/paketo-buildpacks/liberty/internal/util"
+	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
 )
@@ -37,7 +37,7 @@ func testFile(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		testPath, err = ioutil.TempDir("", "file-utils")
+		testPath, err = os.MkdirTemp("", "file-utils")
 		Expect(err).NotTo(HaveOccurred())
 
 		// EvalSymlinks on macOS resolves the temporary directory too so do that here or checking the symlinks will fail

--- a/liberty/base_test.go
+++ b/liberty/base_test.go
@@ -18,11 +18,12 @@ package liberty_test
 
 import (
 	"fmt"
-	"github.com/paketo-buildpacks/libpak/sherpa"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/paketo-buildpacks/libpak/sherpa"
 
 	"github.com/buildpacks/libcnb"
 	"github.com/paketo-buildpacks/liberty/liberty"
@@ -41,17 +42,17 @@ func testBase(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		ctx.Layers.Path, err = ioutil.TempDir("", "base-layers")
+		ctx.Layers.Path, err = os.MkdirTemp("", "base-layers")
 		Expect(err).NotTo(HaveOccurred())
 		ctx.Layers.Path, err = filepath.EvalSymlinks(ctx.Layers.Path)
 		Expect(err).ToNot(HaveOccurred())
 
-		ctx.Application.Path, err = ioutil.TempDir("", "workspace")
+		ctx.Application.Path, err = os.MkdirTemp("", "workspace")
 		Expect(err).ToNot(HaveOccurred())
 		ctx.Application.Path, err = filepath.EvalSymlinks(ctx.Application.Path)
 		Expect(err).ToNot(HaveOccurred())
 
-		ctx.Buildpack.Path, err = ioutil.TempDir("", "base-buildpack")
+		ctx.Buildpack.Path, err = os.MkdirTemp("", "base-buildpack")
 		Expect(err).ToNot(HaveOccurred())
 		ctx.Buildpack.Path, err = filepath.EvalSymlinks(ctx.Buildpack.Path)
 		Expect(err).ToNot(HaveOccurred())
@@ -141,7 +142,7 @@ func testBase(t *testing.T, when spec.G, it spec.S) {
 		Expect(err).ToNot(HaveOccurred())
 		defer xmlFile.Close()
 
-		bytes, err := ioutil.ReadAll(xmlFile)
+		bytes, err := io.ReadAll(xmlFile)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(string(bytes)).To(Equal(`<?xml version="1.0" encoding="UTF-8"?>
 <server>
@@ -175,7 +176,7 @@ func testBase(t *testing.T, when spec.G, it spec.S) {
 		Expect(err).ToNot(HaveOccurred())
 		defer xmlFile.Close()
 
-		bytes, err := ioutil.ReadAll(xmlFile)
+		bytes, err := io.ReadAll(xmlFile)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(string(bytes)).To(Equal(`<?xml version="1.0" encoding="UTF-8"?>
 <server>
@@ -445,7 +446,7 @@ func testBase(t *testing.T, when spec.G, it spec.S) {
 			xmlFile, err := os.Open(filepath.Join(layer.Path, "wlp", "usr", "servers", "defaultServer", "configDropins", "overrides", "app.xml"))
 			Expect(err).ToNot(HaveOccurred())
 			defer xmlFile.Close()
-			bytes, err := ioutil.ReadAll(xmlFile)
+			bytes, err := io.ReadAll(xmlFile)
 			Expect(err).ToNot(HaveOccurred())
 
 			appXML := fmt.Sprintf(`<server><application id="app" name="app" location="%s" context-root="/"/></server>`,
@@ -476,7 +477,7 @@ func testBase(t *testing.T, when spec.G, it spec.S) {
 			xmlFile, err := os.Open(filepath.Join(layer.Path, "wlp", "usr", "servers", "defaultServer", "configDropins", "overrides", "app.xml"))
 			Expect(err).ToNot(HaveOccurred())
 			defer xmlFile.Close()
-			bytes, err := ioutil.ReadAll(xmlFile)
+			bytes, err := io.ReadAll(xmlFile)
 			Expect(err).ToNot(HaveOccurred())
 
 			appXML := fmt.Sprintf(`<server><webApplication id="myapp" name="myapp" location="%s" context-root="/dev"/></server>`,
@@ -501,13 +502,13 @@ func testBase(t *testing.T, when spec.G, it spec.S) {
 			)
 			layer, err := ctx.Layers.Layer("test-layer")
 			Expect(err).ToNot(HaveOccurred())
-			layer, err = base.Contribute(layer)
+			_, err = base.Contribute(layer)
 			Expect(err).ToNot(HaveOccurred())
 
 			xmlFile, err := os.Open(filepath.Join(ctx.Application.Path, "server.xml"))
 			Expect(err).ToNot(HaveOccurred())
 			defer xmlFile.Close()
-			bytes, err := ioutil.ReadAll(xmlFile)
+			bytes, err := io.ReadAll(xmlFile)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(bytes)).To(Equal(`<?xml version="1.0" encoding="UTF-8"?><server><webApplication name="myapp" context-root="/dev" id="app"/></server>`))
 		})
@@ -535,7 +536,7 @@ func testBase(t *testing.T, when spec.G, it spec.S) {
 			xmlFile, err := os.Open(filepath.Join(layer.Path, "wlp", "usr", "servers", "defaultServer", "configDropins", "overrides", "app.xml"))
 			Expect(err).ToNot(HaveOccurred())
 			defer xmlFile.Close()
-			bytes, err := ioutil.ReadAll(xmlFile)
+			bytes, err := io.ReadAll(xmlFile)
 			Expect(err).ToNot(HaveOccurred())
 
 			appXML := fmt.Sprintf(`<server><webApplication id="myapp" name="myapp" location="%s" context-root="/app"/></server>`,

--- a/liberty/build.go
+++ b/liberty/build.go
@@ -18,11 +18,12 @@ package liberty
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/paketo-buildpacks/liberty/internal/util"
 	"github.com/paketo-buildpacks/libpak/bindings"
 	"github.com/paketo-buildpacks/libpak/sherpa"
-	"strconv"
-	"strings"
 
 	"github.com/buildpacks/libcnb"
 	"github.com/paketo-buildpacks/liberty/internal/core"
@@ -148,7 +149,7 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	}
 
 	if b.SBOMScanner == nil {
-		b.SBOMScanner = sbom.NewSyftCLISBOMScanner(context.Layers, b.Executor, b.Logger)
+		b.SBOMScanner = sbom.NewSyftCLISBOMScanner(context.Layers, effect.CommandExecutor{}, b.Logger)
 	}
 
 	installType, _ := cr.Resolve("BP_LIBERTY_INSTALL_TYPE")

--- a/liberty/build_test.go
+++ b/liberty/build_test.go
@@ -18,13 +18,13 @@ package liberty_test
 
 import (
 	"bytes"
-	"github.com/paketo-buildpacks/libpak/effect"
-	"github.com/stretchr/testify/mock"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/paketo-buildpacks/libpak/effect"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/buildpacks/libcnb"
 	. "github.com/onsi/gomega"
@@ -46,7 +46,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Application.Path, err = ioutil.TempDir("", "build-application")
+		t.Setenv("BP_ARCH", "amd64")
+
+		ctx.Application.Path, err = os.MkdirTemp("", "build-application")
 		Expect(err).NotTo(HaveOccurred())
 
 		ctx.Buildpack.Metadata = map[string]interface{}{
@@ -72,7 +74,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			{Name: "java-app-server"},
 		}
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "build-layers")
+		ctx.Layers.Path, err = os.MkdirTemp("", "build-layers")
 		Expect(err).NotTo(HaveOccurred())
 
 		sbomScanner = mocks.SBOMScanner{}
@@ -217,7 +219,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		context("Main-Class in MANIFEST.MF", func() {
 			it.Before(func() {
 				Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
-				Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte(`Main-Class: org.DoStuff`), 0644)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "MANIFEST.MF"), []byte(`Main-Class: org.DoStuff`), 0644)).To(Succeed())
 			})
 
 			it("doesn't run", func() {
@@ -263,7 +265,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.Setenv("BP_LIBERTY_VERSION", "21.0.11")).To(Succeed())
 			Expect(os.Setenv("BP_LIBERTY_PROFILE", "jakartaee10")).To(Succeed())
 			Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
-			Expect(ioutil.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "application.xml"), []byte{}, 0644)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "application.xml"), []byte{}, 0644)).To(Succeed())
 		})
 
 		it.After(func() {

--- a/liberty/detect_test.go
+++ b/liberty/detect_test.go
@@ -17,7 +17,6 @@
 package liberty_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -40,10 +39,10 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Application.Path, err = ioutil.TempDir("", "open-liberty-app")
+		ctx.Application.Path, err = os.MkdirTemp("", "open-liberty-app")
 		Expect(err).NotTo(HaveOccurred())
 
-		ctx.Platform.Path, err = ioutil.TempDir("", "open-liberty-test-platform")
+		ctx.Platform.Path, err = os.MkdirTemp("", "open-liberty-test-platform")
 		Expect(err).NotTo(HaveOccurred())
 
 		ctx.Buildpack.Metadata = map[string]interface{}{

--- a/liberty/distribution_test.go
+++ b/liberty/distribution_test.go
@@ -17,12 +17,12 @@
 package liberty_test
 
 import (
-	"github.com/paketo-buildpacks/liberty/internal/util"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/paketo-buildpacks/liberty/internal/util"
 
 	"github.com/paketo-buildpacks/libpak/effect"
 	"github.com/paketo-buildpacks/libpak/effect/mocks"
@@ -47,7 +47,7 @@ func testDistribution(t *testing.T, when spec.G, it spec.S) {
 	it.Before(func() {
 		var err error
 
-		ctx.Layers.Path, err = ioutil.TempDir("", "home-layers")
+		ctx.Layers.Path, err = os.MkdirTemp("", "home-layers")
 		Expect(err).NotTo(HaveOccurred())
 
 		executor.On("Execute", mock.Anything).Return(nil)
@@ -92,7 +92,7 @@ func testDistribution(t *testing.T, when spec.G, it spec.S) {
 		}
 		dc := libpak.DependencyCache{CachePath: "testdata"}
 
-		iFixesPath, err := ioutil.TempDir("", "ifixes")
+		iFixesPath, err := os.MkdirTemp("", "ifixes")
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(os.MkdirAll(iFixesPath, 0755)).To(Succeed())
@@ -173,7 +173,7 @@ func testDistribution(t *testing.T, when spec.G, it spec.S) {
 
 		Expect(distro.LayerContributor.ExpectedMetadata.(map[string]interface{})).To(HaveKeyWithValue("features", features))
 
-		layer, err = distro.Contribute(layer)
+		_, err = distro.Contribute(layer)
 		Expect(err).NotTo(HaveOccurred())
 
 		installFeatureExecution := executor.Calls[0].Arguments[0].(effect.Execution)

--- a/liberty/feature_test.go
+++ b/liberty/feature_test.go
@@ -18,14 +18,15 @@ package liberty_test
 
 import (
 	"encoding/xml"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
 	. "github.com/onsi/gomega"
 	"github.com/paketo-buildpacks/liberty/liberty"
 	"github.com/paketo-buildpacks/libpak/bard"
 	"github.com/sclevine/spec"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"testing"
 )
 
 func testFeatures(t *testing.T, when spec.G, it spec.S) {
@@ -38,9 +39,9 @@ func testFeatures(t *testing.T, when spec.G, it spec.S) {
 
 	it.Before(func() {
 		var err error
-		configRoot, err = ioutil.TempDir("", "config")
+		configRoot, err = os.MkdirTemp("", "config")
 		Expect(err).NotTo(HaveOccurred())
-		runtimeRoot, err = ioutil.TempDir("", "liberty-runtime")
+		runtimeRoot, err = os.MkdirTemp("", "liberty-runtime")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(os.MkdirAll(filepath.Join(runtimeRoot, "usr", "servers", "defaultServer", "configDropins", "defaults"), 0755)).To(Succeed())
 		Expect(os.MkdirAll(filepath.Join(runtimeRoot, "usr", "extension", "lib", "features"), 0755)).To(Succeed())
@@ -54,7 +55,7 @@ func testFeatures(t *testing.T, when spec.G, it spec.S) {
 
 	when("feature descriptor is not provided", func() {
 		it("should not load any features", func() {
-			desc, err := liberty.ReadFeatureDescriptor(configRoot, bard.NewLogger(ioutil.Discard))
+			desc, err := liberty.ReadFeatureDescriptor(configRoot, bard.NewLogger(io.Discard))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(desc.Features).To(BeEmpty())
 		})
@@ -73,7 +74,7 @@ func testFeatures(t *testing.T, when spec.G, it spec.S) {
 		})
 
 		it("should resolve features", func() {
-			desc, err := liberty.ReadFeatureDescriptor(configRoot, bard.NewLogger(ioutil.Discard))
+			desc, err := liberty.ReadFeatureDescriptor(configRoot, bard.NewLogger(io.Discard))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(desc.Features).To(HaveLen(1))
 
@@ -98,7 +99,7 @@ func testFeatures(t *testing.T, when spec.G, it spec.S) {
 			Expect(os.WriteFile(filepath.Join(configRoot, "features.toml"), []byte(features), 0644)).To(Succeed())
 		})
 		it("should throw an error", func() {
-			desc, err := liberty.ReadFeatureDescriptor(configRoot, bard.NewLogger(ioutil.Discard))
+			desc, err := liberty.ReadFeatureDescriptor(configRoot, bard.NewLogger(io.Discard))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(desc.ResolveFeatures()).ToNot(Succeed())
 		})
@@ -163,7 +164,7 @@ func testFeatures(t *testing.T, when spec.G, it spec.S) {
 			Expect(err).ToNot(HaveOccurred())
 			defer xmlFile.Close()
 
-			bytes, err := ioutil.ReadAll(xmlFile)
+			bytes, err := io.ReadAll(xmlFile)
 			Expect(err).ToNot(HaveOccurred())
 
 			var featureConfig struct {


### PR DESCRIPTION
## Summary
When running `syft`, do not use effect.NewExecutor which runs the command with a tty. This seems to cause an issue with syft (or possibly with our tty library pty), and in either case you end up with stray formatting characters even though we tell syft to be quiet. Using CommandExecutor is basically the same, but it doesn't run with a tty.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
