### PR TITLE
Add new dependency microprofile7 and remove microprofile8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
       directory: /
       schedule:
         interval: daily
-      ignore:
-        - dependency-name: github.com/onsi/gomega
       labels:
         - semver:patch
         - type:dependency-upgrade

--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -68,14 +68,14 @@ dependencies:
     group_id:    io.openliberty
     artifact_id: openliberty-webProfile8
     packaging:   zip
-- id:   open-liberty-runtime-microProfile6
+- id:   open-liberty-runtime-microProfile7
   purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
   with:
     uri:         https://repo1.maven.org/maven2
     group_id:    io.openliberty
-    artifact_id: openliberty-microProfile6
+    artifact_id: openliberty-microProfile7
     packaging:   zip
 - id:   open-liberty-runtime-microProfile4
   purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"

--- a/.github/workflows/pb-create-package.yml
+++ b/.github/workflows/pb-create-package.yml
@@ -11,21 +11,21 @@ jobs:
         steps:
             - name: Docker login gcr.io
               if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
-              uses: docker/login-action@v3
+              uses: docker/login-action@v2
               with:
                 password: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
                 registry: gcr.io
                 username: _json_key
             - name: Docker login docker.io
               if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
-              uses: docker/login-action@v3
+              uses: docker/login-action@v2
               with:
                 password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
                 registry: docker.io
                 username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install create-package
               run: |
                 #!/usr/bin/env bash
@@ -33,13 +33,44 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/create-package@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: buildpacks/github-actions/setup-pack@v5.7.2
-              with:
-                pack-version: 0.34.2
+            - name: Install crane
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing crane ${CRANE_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --show-error \
+                  --silent \
+                  --location \
+                  "https://github.com/google/go-containerregistry/releases/download/v${CRANE_VERSION}/go-containerregistry_Linux_x86_64.tar.gz" \
+                | tar -C "${HOME}/bin" -xz crane
+              env:
+                CRANE_VERSION: 0.8.0
+            - name: Install pack
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing pack ${PACK_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/pack-v${PACK_VERSION}-linux.tgz" \
+                | tar -C "${HOME}"/bin -xz pack
+              env:
+                PACK_VERSION: 0.27.0
             - name: Enable pack Experimental
               if: ${{ false }}
               run: |
@@ -51,9 +82,9 @@ jobs:
 
                 mkdir -p "${HOME}"/.pack
                 echo "experimental = true" >> "${HOME}"/.pack/config.toml
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v3
             - if: ${{ false }}
-              uses: actions/cache@v4
+              uses: actions/cache@v3
               with:
                 key: ${{ runner.os }}-go-${{ hashFiles('**/buildpack.toml', '**/package.toml') }}
                 path: |-
@@ -67,8 +98,8 @@ jobs:
 
                 set -euo pipefail
 
-                if [[ ${GITHUB_REF:-} != "refs/"* ]]; then
-                  echo "GITHUB_REF set to [${GITHUB_REF:-}], but that is unexpected. It should start with 'refs/*'"
+                if [ -z "${GITHUB_REF+set}" ]; then
+                  echo "GITHUB_REF set to [${GITHUB_REF-<unset>}], but should never be empty or unset"
                   exit 255
                 fi
 
@@ -78,15 +109,15 @@ jobs:
                   MAJOR_VERSION="$(echo "${VERSION}" | awk -F '.' '{print $1 }')"
                   MINOR_VERSION="$(echo "${VERSION}" | awk -F '.' '{print $1 "." $2 }')"
 
-                  echo "version-major=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
-                  echo "version-minor=${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
+                  echo "::set-output name=version-major::${MAJOR_VERSION}"
+                  echo "::set-output name=version-minor::${MINOR_VERSION}"
                 elif [[ ${GITHUB_REF} =~ refs/heads/(.+) ]]; then
                   VERSION=${BASH_REMATCH[1]}
                 else
                   VERSION=$(git rev-parse --short HEAD)
                 fi
 
-                echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=version::${VERSION}"
                 echo "Selected ${VERSION} from
                   * ref: ${GITHUB_REF}
                   * sha: ${GITHUB_SHA}
@@ -97,32 +128,23 @@ jobs:
 
                 set -euo pipefail
 
-                # With Go 1.20, we need to set this so that we produce statically compiled binaries
-                #
-                # Starting with Go 1.20, Go will produce binaries that are dynamically linked against libc
-                #   which can cause compatibility issues. The compiler links against libc on the build system
-                #   but that may be newer than on the stacks we support.
-                export CGO_ENABLED=0
-
                 if [[ "${INCLUDE_DEPENDENCIES}" == "true" ]]; then
                   create-package \
-                    --source "${SOURCE_PATH:-.}" \
+                    --source ${SOURCE_PATH:-.} \
                     --cache-location "${HOME}"/carton-cache \
                     --destination "${HOME}"/buildpack \
                     --include-dependencies \
                     --version "${VERSION}"
                 else
                   create-package \
-                    --source "${SOURCE_PATH:-.}" \
+                    --source ${SOURCE_PATH:-.} \
                     --destination "${HOME}"/buildpack \
                     --version "${VERSION}"
                 fi
 
-                PACKAGE_FILE="${SOURCE_PATH:-.}/package.toml"
-                if [ -f "${PACKAGE_FILE}" ]; then
-                  cp "${PACKAGE_FILE}" "${HOME}/buildpack/package.toml"
-                  printf '[buildpack]\nuri = "%s"\n\n[platform]\nos = "%s"\n' "${HOME}/buildpack" "${OS}" >> "${HOME}/buildpack/package.toml"
-                fi
+                PACKAGE_FILE=${SOURCE_PATH:-.}/package.toml
+                [[ -e ${PACKAGE_FILE} ]] && cp ${PACKAGE_FILE} "${HOME}"/package.toml
+                printf '[buildpack]\nuri = "%s"\n\n[platform]\nos = "%s"\n' "${HOME}"/buildpack "${OS}" >> "${HOME}"/package.toml
               env:
                 INCLUDE_DEPENDENCIES: "false"
                 OS: linux
@@ -135,23 +157,15 @@ jobs:
 
                 set -euo pipefail
 
-                COMPILED_BUILDPACK="${HOME}/buildpack"
-
-                # create-package puts the buildpack here, we need to run from that directory
-                #   for component buildpacks so that pack doesn't need a package.toml
-                cd "${COMPILED_BUILDPACK}"
-                CONFIG=""
-                if [ -f "${COMPILED_BUILDPACK}/package.toml" ]; then
-                  CONFIG="--config ${COMPILED_BUILDPACK}/package.toml"
-                fi
 
                 PACKAGE_LIST=($PACKAGES)
                 # Extract first repo (Docker Hub) as the main to package & register
                 PACKAGE=${PACKAGE_LIST[0]}
 
                 if [[ "${PUBLISH:-x}" == "true" ]]; then
-                  pack -v buildpack package \
-                    "${PACKAGE}:${VERSION}" ${CONFIG} \
+                  pack buildpack package \
+                    "${PACKAGE}:${VERSION}" \
+                    --config "${HOME}"/package.toml \
                     --publish
 
                   if [[ -n ${VERSION_MINOR:-} && -n ${VERSION_MAJOR:-} ]]; then
@@ -159,7 +173,7 @@ jobs:
                     crane tag "${PACKAGE}:${VERSION}" "${VERSION_MAJOR}"
                   fi
                   crane tag "${PACKAGE}:${VERSION}" latest
-                  echo "digest=$(crane digest "${PACKAGE}:${VERSION}")" >> "$GITHUB_OUTPUT"
+                  echo "::set-output name=digest::$(crane digest "${PACKAGE}:${VERSION}")"
 
                   # copy to other repositories specified
                   for P in "${PACKAGE_LIST[@]}"
@@ -175,9 +189,10 @@ jobs:
                     done
 
                 else
-                  pack -v buildpack package \
-                    "${PACKAGE}:${VERSION}" ${CONFIG} \
-                    --format "${FORMAT}" $([ -n "$TTL_SH_PUBLISH" ] && [ "$TTL_SH_PUBLISH" = "true" ] && echo "--publish")
+                  pack buildpack package \
+                    "${PACKAGE}:${VERSION}" \
+                    --config "${HOME}"/package.toml \
+                    --format "${FORMAT}"
                 fi
               env:
                 PACKAGES: docker.io/paketobuildpacks/liberty gcr.io/paketo-buildpacks/liberty
@@ -208,7 +223,7 @@ jobs:
                 DIGEST: ${{ steps.package.outputs.digest }}
                 GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
             - if: ${{ true }}
-              uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:5.7.2
+              uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.1
               with:
                 address: docker.io/paketobuildpacks/liberty@${{ steps.package.outputs.digest }}
                 id: paketo-buildpacks/liberty

--- a/.github/workflows/pb-minimal-labels.yml
+++ b/.github/workflows/pb-minimal-labels.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: mheap/github-action-required-labels@v5
+            - uses: mheap/github-action-required-labels@v2
               with:
                 count: 1
                 labels: semver:major, semver:minor, semver:patch
@@ -22,7 +22,7 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: mheap/github-action-required-labels@v5
+            - uses: mheap/github-action-required-labels@v2
               with:
                 count: 1
                 labels: type:bug, type:dependency-upgrade, type:documentation, type:enhancement, type:question, type:task

--- a/.github/workflows/pb-synchronize-labels.yml
+++ b/.github/workflows/pb-synchronize-labels.yml
@@ -11,7 +11,7 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v3
             - uses: micnncim/action-label-syncer@v1
               env:
                 GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -1,10 +1,5 @@
 name: Tests
 "on":
-    merge_group:
-        types:
-            - checks_requested
-        branches:
-            - main
     pull_request: {}
     push:
         branches:
@@ -15,9 +10,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install create-package
               run: |
                 #!/usr/bin/env bash
@@ -25,9 +20,25 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/create-package@latest
-            - uses: buildpacks/github-actions/setup-pack@v5.7.2
-              with:
-                pack-version: 0.34.2
+            - name: Install pack
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing pack ${PACK_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  "https://github.com/buildpacks/pack/releases/download/v${PACK_VERSION}/pack-v${PACK_VERSION}-linux.tgz" \
+                | tar -C "${HOME}"/bin -xz pack
+              env:
+                PACK_VERSION: 0.27.0
             - name: Enable pack Experimental
               if: ${{ false }}
               run: |
@@ -39,8 +50,8 @@ jobs:
 
                 mkdir -p "${HOME}"/.pack
                 echo "experimental = true" >> "${HOME}"/.pack/config.toml
-            - uses: actions/checkout@v4
-            - uses: actions/cache@v4
+            - uses: actions/checkout@v3
+            - uses: actions/cache@v3
               with:
                 key: ${{ runner.os }}-go-${{ hashFiles('**/buildpack.toml', '**/package.toml') }}
                 path: |-
@@ -54,8 +65,8 @@ jobs:
 
                 set -euo pipefail
 
-                if [[ ${GITHUB_REF:-} != "refs/"* ]]; then
-                  echo "GITHUB_REF set to [${GITHUB_REF:-}], but that is unexpected. It should start with 'refs/*'"
+                if [ -z "${GITHUB_REF+set}" ]; then
+                  echo "GITHUB_REF set to [${GITHUB_REF-<unset>}], but should never be empty or unset"
                   exit 255
                 fi
 
@@ -65,15 +76,15 @@ jobs:
                   MAJOR_VERSION="$(echo "${VERSION}" | awk -F '.' '{print $1 }')"
                   MINOR_VERSION="$(echo "${VERSION}" | awk -F '.' '{print $1 "." $2 }')"
 
-                  echo "version-major=${MAJOR_VERSION}" >> "$GITHUB_OUTPUT"
-                  echo "version-minor=${MINOR_VERSION}" >> "$GITHUB_OUTPUT"
+                  echo "::set-output name=version-major::${MAJOR_VERSION}"
+                  echo "::set-output name=version-minor::${MINOR_VERSION}"
                 elif [[ ${GITHUB_REF} =~ refs/heads/(.+) ]]; then
                   VERSION=${BASH_REMATCH[1]}
                 else
                   VERSION=$(git rev-parse --short HEAD)
                 fi
 
-                echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=version::${VERSION}"
                 echo "Selected ${VERSION} from
                   * ref: ${GITHUB_REF}
                   * sha: ${GITHUB_SHA}
@@ -84,32 +95,23 @@ jobs:
 
                 set -euo pipefail
 
-                # With Go 1.20, we need to set this so that we produce statically compiled binaries
-                #
-                # Starting with Go 1.20, Go will produce binaries that are dynamically linked against libc
-                #   which can cause compatibility issues. The compiler links against libc on the build system
-                #   but that may be newer than on the stacks we support.
-                export CGO_ENABLED=0
-
                 if [[ "${INCLUDE_DEPENDENCIES}" == "true" ]]; then
                   create-package \
-                    --source "${SOURCE_PATH:-.}" \
+                    --source ${SOURCE_PATH:-.} \
                     --cache-location "${HOME}"/carton-cache \
                     --destination "${HOME}"/buildpack \
                     --include-dependencies \
                     --version "${VERSION}"
                 else
                   create-package \
-                    --source "${SOURCE_PATH:-.}" \
+                    --source ${SOURCE_PATH:-.} \
                     --destination "${HOME}"/buildpack \
                     --version "${VERSION}"
                 fi
 
-                PACKAGE_FILE="${SOURCE_PATH:-.}/package.toml"
-                if [ -f "${PACKAGE_FILE}" ]; then
-                  cp "${PACKAGE_FILE}" "${HOME}/buildpack/package.toml"
-                  printf '[buildpack]\nuri = "%s"\n\n[platform]\nos = "%s"\n' "${HOME}/buildpack" "${OS}" >> "${HOME}/buildpack/package.toml"
-                fi
+                PACKAGE_FILE=${SOURCE_PATH:-.}/package.toml
+                [[ -e ${PACKAGE_FILE} ]] && cp ${PACKAGE_FILE} "${HOME}"/package.toml
+                printf '[buildpack]\nuri = "%s"\n\n[platform]\nos = "%s"\n' "${HOME}"/buildpack "${OS}" >> "${HOME}"/package.toml
               env:
                 INCLUDE_DEPENDENCIES: "true"
                 OS: linux
@@ -120,23 +122,15 @@ jobs:
 
                 set -euo pipefail
 
-                COMPILED_BUILDPACK="${HOME}/buildpack"
-
-                # create-package puts the buildpack here, we need to run from that directory
-                #   for component buildpacks so that pack doesn't need a package.toml
-                cd "${COMPILED_BUILDPACK}"
-                CONFIG=""
-                if [ -f "${COMPILED_BUILDPACK}/package.toml" ]; then
-                  CONFIG="--config ${COMPILED_BUILDPACK}/package.toml"
-                fi
 
                 PACKAGE_LIST=($PACKAGES)
                 # Extract first repo (Docker Hub) as the main to package & register
                 PACKAGE=${PACKAGE_LIST[0]}
 
                 if [[ "${PUBLISH:-x}" == "true" ]]; then
-                  pack -v buildpack package \
-                    "${PACKAGE}:${VERSION}" ${CONFIG} \
+                  pack buildpack package \
+                    "${PACKAGE}:${VERSION}" \
+                    --config "${HOME}"/package.toml \
                     --publish
 
                   if [[ -n ${VERSION_MINOR:-} && -n ${VERSION_MAJOR:-} ]]; then
@@ -144,7 +138,7 @@ jobs:
                     crane tag "${PACKAGE}:${VERSION}" "${VERSION_MAJOR}"
                   fi
                   crane tag "${PACKAGE}:${VERSION}" latest
-                  echo "digest=$(crane digest "${PACKAGE}:${VERSION}")" >> "$GITHUB_OUTPUT"
+                  echo "::set-output name=digest::$(crane digest "${PACKAGE}:${VERSION}")"
 
                   # copy to other repositories specified
                   for P in "${PACKAGE_LIST[@]}"
@@ -160,29 +154,29 @@ jobs:
                     done
 
                 else
-                  pack -v buildpack package \
-                    "${PACKAGE}:${VERSION}" ${CONFIG} \
-                    --format "${FORMAT}" $([ -n "$TTL_SH_PUBLISH" ] && [ "$TTL_SH_PUBLISH" = "true" ] && echo "--publish")
+                  pack buildpack package \
+                    "${PACKAGE}:${VERSION}" \
+                    --config "${HOME}"/package.toml \
+                    --format "${FORMAT}"
                 fi
               env:
                 FORMAT: image
                 PACKAGES: test
-                TTL_SH_PUBLISH: "false"
                 VERSION: ${{ steps.version.outputs.version }}
     unit:
         name: Unit Test
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
-            - uses: actions/cache@v4
+            - uses: actions/checkout@v3
+            - uses: actions/cache@v3
               with:
                 key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
                 path: ${{ env.HOME }}/go/pkg/mod
                 restore-keys: ${{ runner.os }}-go-
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install richgo
               run: |
                 #!/usr/bin/env bash

--- a/.github/workflows/pb-update-draft-release.yml
+++ b/.github/workflows/pb-update-draft-release.yml
@@ -13,7 +13,21 @@ jobs:
               uses: release-drafter/release-drafter@v5
               env:
                 GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-            - uses: actions/checkout@v4
+            - name: Docker login gcr.io
+              if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
+              uses: docker/login-action@v2
+              with:
+                password: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
+                registry: gcr.io
+                username: _json_key
+            - name: Docker login docker.io
+              if: ${{ (github.event_name != 'pull_request' || ! github.event.pull_request.head.repo.fork) && (github.actor != 'dependabot[bot]') }}
+              uses: docker/login-action@v2
+              with:
+                password: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
+                registry: docker.io
+                username: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
+            - uses: actions/checkout@v3
             - name: Update draft release with buildpack information
               uses: docker://ghcr.io/paketo-buildpacks/actions/draft-release:main
               with:

--- a/.github/workflows/pb-update-go.yml
+++ b/.github/workflows/pb-update-go.yml
@@ -1,7 +1,7 @@
 name: Update Go
 "on":
     schedule:
-        - cron: 40 2 * * 1
+        - cron: 0 2 * * 1
     workflow_dispatch: {}
 jobs:
     update:
@@ -9,10 +9,10 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
-            - uses: actions/checkout@v4
+                go-version: "1.18"
+            - uses: actions/checkout@v3
             - name: Update Go Version & Modules
               id: update-go
               run: |
@@ -25,11 +25,11 @@ jobs:
                     exit 1
                 fi
 
-                OLD_GO_VERSION=$(grep -P '^go \d\.\d+' go.mod | cut -d ' ' -f 2 | cut -d '.' -f 1-2)
+                OLD_GO_VERSION=$(grep -P '^go \d\.\d+' go.mod | cut -d ' ' -f 2)
 
                 go mod edit -go="$GO_VERSION"
                 go mod tidy
-                go get -u -t ./...
+                go get -u all
                 go mod tidy
 
                 git add go.mod go.sum
@@ -45,12 +45,12 @@ jobs:
                     COMMIT_SEMVER="semver:minor"
                 fi
 
-                echo "commit-title=${COMMIT_TITLE}" >> "$GITHUB_OUTPUT"
-                echo "commit-body=${COMMIT_BODY}" >> "$GITHUB_OUTPUT"
-                echo "commit-semver=${COMMIT_SEMVER}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=commit-title::${COMMIT_TITLE}"
+                echo "::set-output name=commit-body::${COMMIT_BODY}"
+                echo "::set-output name=commit-semver::${COMMIT_SEMVER}"
               env:
-                GO_VERSION: "1.23"
-            - uses: peter-evans/create-pull-request@v6
+                GO_VERSION: "1.18"
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: |-

--- a/.github/workflows/pb-update-open-liberty-runtime-full.yml
+++ b/.github/workflows/pb-update-open-liberty-runtime-full.yml
@@ -9,9 +9,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,11 +19,28 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: actions/checkout@v4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
@@ -33,24 +50,20 @@ jobs:
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |
+              run: |-
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
-                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
-                ARCH=${ARCH:-amd64}
-                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
-
-                if [ -z "$OLD_VERSION" ]; then
-                  ARCH="" # empty means noarch
-                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
-                fi
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
 
                 update-buildpack-dependency \
                   --buildpack-toml buildpack.toml \
                   --id "${ID}" \
-                  --arch "${ARCH}" \
                   --version-pattern "${VERSION_PATTERN}" \
                   --version "${VERSION}" \
                   --cpe-pattern "${CPE_PATTERN:-}" \
@@ -58,9 +71,7 @@ jobs:
                   --purl-pattern "${PURL_PATTERN:-}" \
                   --purl "${PURL:-}" \
                   --uri "${URI}" \
-                  --sha256 "${SHA256}" \
-                  --source "${SOURCE_URI}" \
-                  --source-sha256 "${SOURCE_SHA256}"
+                  --sha256 "${SHA256}"
 
                 git add buildpack.toml
                 git checkout -- .
@@ -73,23 +84,20 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
-                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
               env:
-                ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-full
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
-                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
-                SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
                 VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps `open-liberty-runtime-full` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.

--- a/.github/workflows/pb-update-open-liberty-runtime-jakartaee-10.yml
+++ b/.github/workflows/pb-update-open-liberty-runtime-jakartaee-10.yml
@@ -9,9 +9,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,11 +19,28 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: actions/checkout@v4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
@@ -33,24 +50,20 @@ jobs:
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |
+              run: |-
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
-                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
-                ARCH=${ARCH:-amd64}
-                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
-
-                if [ -z "$OLD_VERSION" ]; then
-                  ARCH="" # empty means noarch
-                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
-                fi
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
 
                 update-buildpack-dependency \
                   --buildpack-toml buildpack.toml \
                   --id "${ID}" \
-                  --arch "${ARCH}" \
                   --version-pattern "${VERSION_PATTERN}" \
                   --version "${VERSION}" \
                   --cpe-pattern "${CPE_PATTERN:-}" \
@@ -58,9 +71,7 @@ jobs:
                   --purl-pattern "${PURL_PATTERN:-}" \
                   --purl "${PURL:-}" \
                   --uri "${URI}" \
-                  --sha256 "${SHA256}" \
-                  --source "${SOURCE_URI}" \
-                  --source-sha256 "${SOURCE_SHA256}"
+                  --sha256 "${SHA256}"
 
                 git add buildpack.toml
                 git checkout -- .
@@ -73,23 +84,20 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
-                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
               env:
-                ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-jakartaee10
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
-                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
-                SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
                 VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps `open-liberty-runtime-jakartaee10` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.

--- a/.github/workflows/pb-update-open-liberty-runtime-javaee-8.yml
+++ b/.github/workflows/pb-update-open-liberty-runtime-javaee-8.yml
@@ -9,9 +9,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,11 +19,28 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: actions/checkout@v4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
@@ -33,24 +50,20 @@ jobs:
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |
+              run: |-
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
-                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
-                ARCH=${ARCH:-amd64}
-                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
-
-                if [ -z "$OLD_VERSION" ]; then
-                  ARCH="" # empty means noarch
-                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
-                fi
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
 
                 update-buildpack-dependency \
                   --buildpack-toml buildpack.toml \
                   --id "${ID}" \
-                  --arch "${ARCH}" \
                   --version-pattern "${VERSION_PATTERN}" \
                   --version "${VERSION}" \
                   --cpe-pattern "${CPE_PATTERN:-}" \
@@ -58,9 +71,7 @@ jobs:
                   --purl-pattern "${PURL_PATTERN:-}" \
                   --purl "${PURL:-}" \
                   --uri "${URI}" \
-                  --sha256 "${SHA256}" \
-                  --source "${SOURCE_URI}" \
-                  --source-sha256 "${SOURCE_SHA256}"
+                  --sha256 "${SHA256}"
 
                 git add buildpack.toml
                 git checkout -- .
@@ -73,23 +84,20 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
-                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
               env:
-                ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-javaee8
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
-                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
-                SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
                 VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps `open-liberty-runtime-javaee8` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.

--- a/.github/workflows/pb-update-open-liberty-runtime-kernel.yml
+++ b/.github/workflows/pb-update-open-liberty-runtime-kernel.yml
@@ -9,9 +9,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,11 +19,28 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: actions/checkout@v4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
@@ -33,24 +50,20 @@ jobs:
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |
+              run: |-
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
-                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
-                ARCH=${ARCH:-amd64}
-                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
-
-                if [ -z "$OLD_VERSION" ]; then
-                  ARCH="" # empty means noarch
-                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
-                fi
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
 
                 update-buildpack-dependency \
                   --buildpack-toml buildpack.toml \
                   --id "${ID}" \
-                  --arch "${ARCH}" \
                   --version-pattern "${VERSION_PATTERN}" \
                   --version "${VERSION}" \
                   --cpe-pattern "${CPE_PATTERN:-}" \
@@ -58,9 +71,7 @@ jobs:
                   --purl-pattern "${PURL_PATTERN:-}" \
                   --purl "${PURL:-}" \
                   --uri "${URI}" \
-                  --sha256 "${SHA256}" \
-                  --source "${SOURCE_URI}" \
-                  --source-sha256 "${SOURCE_SHA256}"
+                  --sha256 "${SHA256}"
 
                 git add buildpack.toml
                 git checkout -- .
@@ -73,23 +84,20 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
-                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
               env:
-                ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-kernel
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
-                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
-                SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
                 VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps `open-liberty-runtime-kernel` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.

--- a/.github/workflows/pb-update-open-liberty-runtime-micro-profile-3.yml
+++ b/.github/workflows/pb-update-open-liberty-runtime-micro-profile-3.yml
@@ -9,9 +9,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,11 +19,28 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: actions/checkout@v4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
@@ -33,24 +50,20 @@ jobs:
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |
+              run: |-
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
-                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
-                ARCH=${ARCH:-amd64}
-                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
-
-                if [ -z "$OLD_VERSION" ]; then
-                  ARCH="" # empty means noarch
-                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
-                fi
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
 
                 update-buildpack-dependency \
                   --buildpack-toml buildpack.toml \
                   --id "${ID}" \
-                  --arch "${ARCH}" \
                   --version-pattern "${VERSION_PATTERN}" \
                   --version "${VERSION}" \
                   --cpe-pattern "${CPE_PATTERN:-}" \
@@ -58,9 +71,7 @@ jobs:
                   --purl-pattern "${PURL_PATTERN:-}" \
                   --purl "${PURL:-}" \
                   --uri "${URI}" \
-                  --sha256 "${SHA256}" \
-                  --source "${SOURCE_URI}" \
-                  --source-sha256 "${SOURCE_SHA256}"
+                  --sha256 "${SHA256}"
 
                 git add buildpack.toml
                 git checkout -- .
@@ -73,23 +84,20 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
-                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
               env:
-                ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-microProfile3
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
-                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
-                SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
                 VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps `open-liberty-runtime-microProfile3` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.

--- a/.github/workflows/pb-update-open-liberty-runtime-micro-profile-4.yml
+++ b/.github/workflows/pb-update-open-liberty-runtime-micro-profile-4.yml
@@ -9,9 +9,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,11 +19,28 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: actions/checkout@v4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
@@ -33,24 +50,20 @@ jobs:
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |
+              run: |-
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
-                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
-                ARCH=${ARCH:-amd64}
-                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
-
-                if [ -z "$OLD_VERSION" ]; then
-                  ARCH="" # empty means noarch
-                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
-                fi
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
 
                 update-buildpack-dependency \
                   --buildpack-toml buildpack.toml \
                   --id "${ID}" \
-                  --arch "${ARCH}" \
                   --version-pattern "${VERSION_PATTERN}" \
                   --version "${VERSION}" \
                   --cpe-pattern "${CPE_PATTERN:-}" \
@@ -58,9 +71,7 @@ jobs:
                   --purl-pattern "${PURL_PATTERN:-}" \
                   --purl "${PURL:-}" \
                   --uri "${URI}" \
-                  --sha256 "${SHA256}" \
-                  --source "${SOURCE_URI}" \
-                  --source-sha256 "${SOURCE_SHA256}"
+                  --sha256 "${SHA256}"
 
                 git add buildpack.toml
                 git checkout -- .
@@ -73,23 +84,20 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
-                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
               env:
-                ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-microProfile4
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
-                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
-                SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
                 VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps `open-liberty-runtime-microProfile4` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.

--- a/.github/workflows/pb-update-open-liberty-runtime-micro-profile-7.yml
+++ b/.github/workflows/pb-update-open-liberty-runtime-micro-profile-7.yml
@@ -1,4 +1,4 @@
-name: Update websphere-liberty-runtime-webProfile8
+name: Update open-liberty-runtime-microProfile7
 "on":
     schedule:
         - cron: 0 5 * * 1-5
@@ -44,8 +44,8 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
-                artifact_id: wlp-webProfile8
-                group_id: com.ibm.websphere.appserver.runtime
+                artifact_id: openliberty-microProfile7
+                group_id: io.openliberty
                 packaging: zip
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
@@ -90,7 +90,7 @@ jobs:
               env:
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
-                ID: websphere-liberty-runtime-webProfile8
+                ID: open-liberty-runtime-microProfile7
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
@@ -100,14 +100,14 @@ jobs:
             - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
-                body: Bumps `websphere-liberty-runtime-webProfile8` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
-                branch: update/buildpack/websphere-liberty-runtime-web-profile-8
+                body: Bumps `open-liberty-runtime-microProfile7` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/open-liberty-runtime-micro-profile-7
                 commit-message: |-
-                    Bump websphere-liberty-runtime-webProfile8 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                    Bump open-liberty-runtime-microProfile7 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
 
-                    Bumps websphere-liberty-runtime-webProfile8 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                    Bumps open-liberty-runtime-microProfile7 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
                 delete-branch: true
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
-                title: Bump websphere-liberty-runtime-webProfile8 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                title: Bump open-liberty-runtime-microProfile7 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-open-liberty-runtime-web-profile-10.yml
+++ b/.github/workflows/pb-update-open-liberty-runtime-web-profile-10.yml
@@ -9,9 +9,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,11 +19,28 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: actions/checkout@v4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
@@ -33,24 +50,20 @@ jobs:
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |
+              run: |-
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
-                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
-                ARCH=${ARCH:-amd64}
-                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
-
-                if [ -z "$OLD_VERSION" ]; then
-                  ARCH="" # empty means noarch
-                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
-                fi
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
 
                 update-buildpack-dependency \
                   --buildpack-toml buildpack.toml \
                   --id "${ID}" \
-                  --arch "${ARCH}" \
                   --version-pattern "${VERSION_PATTERN}" \
                   --version "${VERSION}" \
                   --cpe-pattern "${CPE_PATTERN:-}" \
@@ -58,9 +71,7 @@ jobs:
                   --purl-pattern "${PURL_PATTERN:-}" \
                   --purl "${PURL:-}" \
                   --uri "${URI}" \
-                  --sha256 "${SHA256}" \
-                  --source "${SOURCE_URI}" \
-                  --source-sha256 "${SOURCE_SHA256}"
+                  --sha256 "${SHA256}"
 
                 git add buildpack.toml
                 git checkout -- .
@@ -73,23 +84,20 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
-                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
               env:
-                ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-webProfile10
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
-                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
-                SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
                 VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps `open-liberty-runtime-webProfile10` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.

--- a/.github/workflows/pb-update-open-liberty-runtime-web-profile-8.yml
+++ b/.github/workflows/pb-update-open-liberty-runtime-web-profile-8.yml
@@ -9,9 +9,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,11 +19,28 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: actions/checkout@v4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
@@ -33,24 +50,20 @@ jobs:
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |
+              run: |-
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
-                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
-                ARCH=${ARCH:-amd64}
-                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
-
-                if [ -z "$OLD_VERSION" ]; then
-                  ARCH="" # empty means noarch
-                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
-                fi
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
 
                 update-buildpack-dependency \
                   --buildpack-toml buildpack.toml \
                   --id "${ID}" \
-                  --arch "${ARCH}" \
                   --version-pattern "${VERSION_PATTERN}" \
                   --version "${VERSION}" \
                   --cpe-pattern "${CPE_PATTERN:-}" \
@@ -58,9 +71,7 @@ jobs:
                   --purl-pattern "${PURL_PATTERN:-}" \
                   --purl "${PURL:-}" \
                   --uri "${URI}" \
-                  --sha256 "${SHA256}" \
-                  --source "${SOURCE_URI}" \
-                  --source-sha256 "${SOURCE_SHA256}"
+                  --sha256 "${SHA256}"
 
                 git add buildpack.toml
                 git checkout -- .
@@ -73,23 +84,20 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
-                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
               env:
-                ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: open-liberty-runtime-webProfile8
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
-                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
-                SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
                 VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps `open-liberty-runtime-webProfile8` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.

--- a/.github/workflows/pb-update-pipeline.yml
+++ b/.github/workflows/pb-update-pipeline.yml
@@ -14,9 +14,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install octo
               run: |
                 #!/usr/bin/env bash
@@ -24,7 +24,7 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/pipeline-builder/cmd/octo@latest
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v3
             - name: Update Pipeline
               id: pipeline
               run: |
@@ -55,23 +55,15 @@ jobs:
                 )
 
                 git add .github/
-                git add .gitignore
-
-                if [ -f scripts/build.sh ]; then
-                  git add scripts/build.sh
-                fi
-
                 git checkout -- .
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-
-                DELIMITER=$(openssl rand -hex 16) # roughly the same entropy as uuid v4 used in https://github.com/actions/toolkit/blob/b36e70495fbee083eb20f600eafa9091d832577d/packages/core/src/file-command.ts#L28
-                printf "release-notes<<%s\n%s\n%s\n" "${DELIMITER}" "${RELEASE_NOTES}" "${DELIMITER}" >> "${GITHUB_OUTPUT}" # see https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${NEW_VERSION}"
+                echo "::set-output name=release-notes::${RELEASE_NOTES//$'\n'/%0A}"
               env:
                 DESCRIPTOR: .github/pipeline-descriptor.yml
                 GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: |-

--- a/.github/workflows/pb-update-websphere-liberty-runtime-jakartaee-10.yml
+++ b/.github/workflows/pb-update-websphere-liberty-runtime-jakartaee-10.yml
@@ -9,9 +9,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,11 +19,28 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: actions/checkout@v4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
@@ -33,24 +50,20 @@ jobs:
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |
+              run: |-
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
-                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
-                ARCH=${ARCH:-amd64}
-                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
-
-                if [ -z "$OLD_VERSION" ]; then
-                  ARCH="" # empty means noarch
-                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
-                fi
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
 
                 update-buildpack-dependency \
                   --buildpack-toml buildpack.toml \
                   --id "${ID}" \
-                  --arch "${ARCH}" \
                   --version-pattern "${VERSION_PATTERN}" \
                   --version "${VERSION}" \
                   --cpe-pattern "${CPE_PATTERN:-}" \
@@ -58,9 +71,7 @@ jobs:
                   --purl-pattern "${PURL_PATTERN:-}" \
                   --purl "${PURL:-}" \
                   --uri "${URI}" \
-                  --sha256 "${SHA256}" \
-                  --source "${SOURCE_URI}" \
-                  --source-sha256 "${SOURCE_SHA256}"
+                  --sha256 "${SHA256}"
 
                 git add buildpack.toml
                 git checkout -- .
@@ -73,23 +84,20 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
-                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
               env:
-                ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: websphere-liberty-runtime-jakartaee10
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
-                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
-                SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
                 VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps `websphere-liberty-runtime-jakartaee10` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.

--- a/.github/workflows/pb-update-websphere-liberty-runtime-javaee-7.yml
+++ b/.github/workflows/pb-update-websphere-liberty-runtime-javaee-7.yml
@@ -9,9 +9,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,11 +19,28 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: actions/checkout@v4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
@@ -33,24 +50,20 @@ jobs:
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |
+              run: |-
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
-                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
-                ARCH=${ARCH:-amd64}
-                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
-
-                if [ -z "$OLD_VERSION" ]; then
-                  ARCH="" # empty means noarch
-                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
-                fi
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
 
                 update-buildpack-dependency \
                   --buildpack-toml buildpack.toml \
                   --id "${ID}" \
-                  --arch "${ARCH}" \
                   --version-pattern "${VERSION_PATTERN}" \
                   --version "${VERSION}" \
                   --cpe-pattern "${CPE_PATTERN:-}" \
@@ -58,9 +71,7 @@ jobs:
                   --purl-pattern "${PURL_PATTERN:-}" \
                   --purl "${PURL:-}" \
                   --uri "${URI}" \
-                  --sha256 "${SHA256}" \
-                  --source "${SOURCE_URI}" \
-                  --source-sha256 "${SOURCE_SHA256}"
+                  --sha256 "${SHA256}"
 
                 git add buildpack.toml
                 git checkout -- .
@@ -73,23 +84,20 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
-                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
               env:
-                ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: websphere-liberty-runtime-javaee7
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
-                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
-                SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
                 VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps `websphere-liberty-runtime-javaee7` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.

--- a/.github/workflows/pb-update-websphere-liberty-runtime-javaee-8.yml
+++ b/.github/workflows/pb-update-websphere-liberty-runtime-javaee-8.yml
@@ -9,9 +9,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,11 +19,28 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: actions/checkout@v4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
@@ -33,24 +50,20 @@ jobs:
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |
+              run: |-
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
-                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
-                ARCH=${ARCH:-amd64}
-                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
-
-                if [ -z "$OLD_VERSION" ]; then
-                  ARCH="" # empty means noarch
-                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
-                fi
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
 
                 update-buildpack-dependency \
                   --buildpack-toml buildpack.toml \
                   --id "${ID}" \
-                  --arch "${ARCH}" \
                   --version-pattern "${VERSION_PATTERN}" \
                   --version "${VERSION}" \
                   --cpe-pattern "${CPE_PATTERN:-}" \
@@ -58,9 +71,7 @@ jobs:
                   --purl-pattern "${PURL_PATTERN:-}" \
                   --purl "${PURL:-}" \
                   --uri "${URI}" \
-                  --sha256 "${SHA256}" \
-                  --source "${SOURCE_URI}" \
-                  --source-sha256 "${SOURCE_SHA256}"
+                  --sha256 "${SHA256}"
 
                 git add buildpack.toml
                 git checkout -- .
@@ -73,23 +84,20 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
-                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
               env:
-                ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: websphere-liberty-runtime-javaee8
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
-                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
-                SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
                 VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps `websphere-liberty-runtime-javaee8` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.

--- a/.github/workflows/pb-update-websphere-liberty-runtime-kernel.yml
+++ b/.github/workflows/pb-update-websphere-liberty-runtime-kernel.yml
@@ -9,9 +9,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,11 +19,28 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: actions/checkout@v4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
@@ -33,24 +50,20 @@ jobs:
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |
+              run: |-
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
-                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
-                ARCH=${ARCH:-amd64}
-                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
-
-                if [ -z "$OLD_VERSION" ]; then
-                  ARCH="" # empty means noarch
-                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
-                fi
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
 
                 update-buildpack-dependency \
                   --buildpack-toml buildpack.toml \
                   --id "${ID}" \
-                  --arch "${ARCH}" \
                   --version-pattern "${VERSION_PATTERN}" \
                   --version "${VERSION}" \
                   --cpe-pattern "${CPE_PATTERN:-}" \
@@ -58,9 +71,7 @@ jobs:
                   --purl-pattern "${PURL_PATTERN:-}" \
                   --purl "${PURL:-}" \
                   --uri "${URI}" \
-                  --sha256 "${SHA256}" \
-                  --source "${SOURCE_URI}" \
-                  --source-sha256 "${SOURCE_SHA256}"
+                  --sha256 "${SHA256}"
 
                 git add buildpack.toml
                 git checkout -- .
@@ -73,23 +84,20 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
-                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
               env:
-                ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: websphere-liberty-runtime-kernel
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
-                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
-                SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
                 VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps `websphere-liberty-runtime-kernel` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.

--- a/.github/workflows/pb-update-websphere-liberty-runtime-web-profile-10.yml
+++ b/.github/workflows/pb-update-websphere-liberty-runtime-web-profile-10.yml
@@ -9,9 +9,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,11 +19,28 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: actions/checkout@v4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
@@ -33,24 +50,20 @@ jobs:
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |
+              run: |-
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
-                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
-                ARCH=${ARCH:-amd64}
-                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
-
-                if [ -z "$OLD_VERSION" ]; then
-                  ARCH="" # empty means noarch
-                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
-                fi
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
 
                 update-buildpack-dependency \
                   --buildpack-toml buildpack.toml \
                   --id "${ID}" \
-                  --arch "${ARCH}" \
                   --version-pattern "${VERSION_PATTERN}" \
                   --version "${VERSION}" \
                   --cpe-pattern "${CPE_PATTERN:-}" \
@@ -58,9 +71,7 @@ jobs:
                   --purl-pattern "${PURL_PATTERN:-}" \
                   --purl "${PURL:-}" \
                   --uri "${URI}" \
-                  --sha256 "${SHA256}" \
-                  --source "${SOURCE_URI}" \
-                  --source-sha256 "${SOURCE_SHA256}"
+                  --sha256 "${SHA256}"
 
                 git add buildpack.toml
                 git checkout -- .
@@ -73,23 +84,20 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
-                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
               env:
-                ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: websphere-liberty-runtime-webProfile10
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
-                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
-                SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
                 VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps `websphere-liberty-runtime-webProfile10` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.

--- a/.github/workflows/pb-update-websphere-liberty-runtime-web-profile-7.yml
+++ b/.github/workflows/pb-update-websphere-liberty-runtime-web-profile-7.yml
@@ -9,9 +9,9 @@ jobs:
         runs-on:
             - ubuntu-latest
         steps:
-            - uses: actions/setup-go@v5
+            - uses: actions/setup-go@v3
               with:
-                go-version: "1.23"
+                go-version: "1.18"
             - name: Install update-buildpack-dependency
               run: |
                 #!/usr/bin/env bash
@@ -19,11 +19,28 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/update-buildpack-dependency@latest
-            - uses: buildpacks/github-actions/setup-tools@v5.7.2
-              with:
-                crane-version: 0.19.1
-                yj-version: 5.1.0
-            - uses: actions/checkout@v4
+            - name: Install yj
+              run: |
+                #!/usr/bin/env bash
+
+                set -euo pipefail
+
+                echo "Installing yj ${YJ_VERSION}"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl \
+                  --location \
+                  --show-error \
+                  --silent \
+                  --output "${HOME}"/bin/yj \
+                  "https://github.com/sclevine/yj/releases/download/v${YJ_VERSION}/yj-linux"
+
+                chmod +x "${HOME}"/bin/yj
+              env:
+                YJ_VERSION: 5.0.0
+            - uses: actions/checkout@v3
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
@@ -33,24 +50,20 @@ jobs:
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
               id: buildpack
-              run: |
+              run: |-
                 #!/usr/bin/env bash
 
                 set -euo pipefail
 
-                VERSION_DEPS=$(yj -tj < buildpack.toml | jq -r ".metadata.dependencies[] | select( .id == env.ID ) | select( .version | test( env.VERSION_PATTERN ) )")
-                ARCH=${ARCH:-amd64}
-                OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r 'select( .purl | contains( env.ARCH ) ) | .version')
-
-                if [ -z "$OLD_VERSION" ]; then
-                  ARCH="" # empty means noarch
-                  OLD_VERSION=$(echo "$VERSION_DEPS" | jq -r ".version")
-                fi
+                OLD_VERSION=$(yj -tj < buildpack.toml | jq -r "
+                  .metadata.dependencies[] |
+                  select( .id == env.ID ) |
+                  select( .version | test( env.VERSION_PATTERN ) ) |
+                  .version")
 
                 update-buildpack-dependency \
                   --buildpack-toml buildpack.toml \
                   --id "${ID}" \
-                  --arch "${ARCH}" \
                   --version-pattern "${VERSION_PATTERN}" \
                   --version "${VERSION}" \
                   --cpe-pattern "${CPE_PATTERN:-}" \
@@ -58,9 +71,7 @@ jobs:
                   --purl-pattern "${PURL_PATTERN:-}" \
                   --purl "${PURL:-}" \
                   --uri "${URI}" \
-                  --sha256 "${SHA256}" \
-                  --source "${SOURCE_URI}" \
-                  --source-sha256 "${SOURCE_SHA256}"
+                  --sha256 "${SHA256}"
 
                 git add buildpack.toml
                 git checkout -- .
@@ -73,23 +84,20 @@ jobs:
                   LABEL="semver:patch"
                 fi
 
-                echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"
-                echo "new-version=${VERSION}" >> "$GITHUB_OUTPUT"
-                echo "version-label=${LABEL}" >> "$GITHUB_OUTPUT"
+                echo "::set-output name=old-version::${OLD_VERSION}"
+                echo "::set-output name=new-version::${VERSION}"
+                echo "::set-output name=version-label::${LABEL}"
               env:
-                ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 ID: websphere-liberty-runtime-webProfile7
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
-                SOURCE_SHA256: ${{ steps.dependency.outputs.source_sha256 }}
-                SOURCE_URI: ${{ steps.dependency.outputs.source }}
                 URI: ${{ steps.dependency.outputs.uri }}
                 VERSION: ${{ steps.dependency.outputs.version }}
                 VERSION_PATTERN: '[\d]+\.[\d]+\.[\d]+'
-            - uses: peter-evans/create-pull-request@v6
+            - uses: peter-evans/create-pull-request@v4
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
                 body: Bumps `websphere-liberty-runtime-webProfile7` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Valid profiles for Open Liberty are:
 * javaee8
 * webProfile9
 * webProfile8
-* microProfile6
+* microProfile7
 * microProfile4
 
 Valid profiles for WebSphere Liberty are:

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -203,15 +203,15 @@ api = "0.7"
 
   [[metadata.dependencies]]
     cpes = ["cpe:2.3:a:ibm:open_liberty:24.0.0.11:*:*:*:*:*:*:*"]
-    id = "open-liberty-runtime-microProfile6"
+    id = "open-liberty-runtime-microProfile7"
     name = "Open Liberty (Micro Profile 6)"
-    purl = "pkg:maven/io.openliberty/openliberty-microProfile6@24.0.0.11"
-    sha256 = "16c834a41a01f77ec826d9b0f334aed447801b1d9f3fc05f5ac8cf6e0a4736ac"
-    source = "https://github.com/OpenLiberty/open-liberty/archive/refs/tags/gm-24.0.0.11.tar.gz"
-    source-sha256 = "320cf36d310438d615a79350c8de4a737ff697ef45664c5671682284b9c647bb"
+    purl = "pkg:maven/io.openliberty/openliberty-microProfile7@24.0.0.12"
+    sha256 = "7ae78f24eedbff28f5128017a28d559ae81f48eb0bea0b034577fca81c1b06d7"
+    source = "https://github.com/OpenLiberty/open-liberty/archive/refs/tags/gm-24.0.0.12.tar.gz"
+    source-sha256 = "57ff32688ecb5b6d1852e15c7ca388dda13d76d1e218f29a8dae1e552de39fcf"
     stacks = ["*"]
-    uri = "https://repo1.maven.org/maven2/io/openliberty/openliberty-microProfile6/24.0.0.11/openliberty-microProfile6-24.0.0.11.zip"
-    version = "24.0.11"
+    uri = "https://repo1.maven.org/maven2/io/openliberty/openliberty-microProfile7/24.0.0.17/openliberty-microProfile7-24.0.0.12.zip"
+    version = "24.0.12"
 
     [[metadata.dependencies.licenses]]
       type = "EPL-2.0"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -108,7 +108,7 @@ func IsValidOpenLibertyProfile(profile string) bool {
 		profile == "javaee8" ||
 		profile == "webProfile10" ||
 		profile == "webProfile8" ||
-		profile == "microProfile6" ||
+		profile == "microProfile7" ||
 		profile == "microProfile4"
 }
 
@@ -134,8 +134,8 @@ func GetDefaultFeatures(serverProfile string) []string {
 		return []string{"webProfile-10.0"}
 	case "webProfile8":
 		return []string{"webProfile-8.0"}
-	case "microProfile5":
-		return []string{"microProfile-6.0"}
+	case "microProfile7":
+		return []string{"microProfile-7.0"}
 	case "microProfile4":
 		return []string{"microProfile-4.1"}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Open Liberty has added a new dependency jar, microprofile7 and removed microprofile6.   microprofile6 is EOL and is no longer being produced by Open Liberty.  

## Use Cases
<!-- An explanation of the use cases your change enables -->
Adding the microprofile7 dependency alows users to use the new profile.  

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
