### PR TITLE
Replace gcr.io with docker.io

### DIFF
--- a/docs/using-liberty-stack.md
+++ b/docs/using-liberty-stack.md
@@ -186,34 +186,34 @@ images that you have prepared earlier.
 
 ```toml
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/ca-certificates"
+  uri = "docker://docker.io/paketobuildpacks/ca-certificates"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/eclipse-openj9"
+  uri = "docker://docker.io/paketobuildpacks/eclipse-openj9"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/syft"
+  uri = "docker://docker.io/paketobuildpacks/syft"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/leiningen"
+  uri = "docker://docker.io/paketobuildpacks/leiningen"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/gradle"
+  uri = "docker://docker.io/paketobuildpacks/gradle"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/maven"
+  uri = "docker://docker.io/paketobuildpacks/maven"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/liberty"
+  uri = "docker://docker.io/paketobuildpacks/liberty"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/procfile"
+  uri = "docker://docker.io/paketobuildpacks/procfile"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/environment-variables"
+  uri = "docker://docker.io/paketobuildpacks/environment-variables"
 
 [[buildpacks]]
-  uri = "docker://gcr.io/paketo-buildpacks/image-labels"
+  uri = "docker://docker.io/paketobuildpacks/image-labels"
 
 [[order]]
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Replacing gcr.io references in the docs with docker.io.
## Use Cases
<!-- An explanation of the use cases your change enables -->
Paketo will stop publishing images to gcr.io 
## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
