### PR TITLE
Updates for WLP and OL 26.0.0.5

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -29,14 +29,14 @@ dependencies:
     group_id:    io.openliberty
     artifact_id: openliberty-runtime
     packaging:   zip
-- id:   open-liberty-runtime-jakartaee10
+- id:   open-liberty-runtime-jakartaee11
   purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
   with:
     uri:         https://repo1.maven.org/maven2
     group_id:    io.openliberty
-    artifact_id: openliberty-jakartaee10
+    artifact_id: openliberty-jakartaee11
     packaging:   zip
 - id:   open-liberty-runtime-javaee8
   purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
@@ -47,14 +47,14 @@ dependencies:
     group_id:    io.openliberty
     artifact_id: openliberty-javaee8
     packaging:   zip
-- id:   open-liberty-runtime-webProfile10
+- id:   open-liberty-runtime-webProfile11
   purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
   with:
     uri:         https://repo1.maven.org/maven2
     group_id:    io.openliberty
-    artifact_id: openliberty-webProfile10
+    artifact_id: openliberty-webProfile11
     packaging:   zip
 - id:   open-liberty-runtime-webProfile8
   purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
@@ -101,23 +101,23 @@ dependencies:
     group_id:    com.ibm.websphere.appserver.runtime
     artifact_id: wlp-kernel
     packaging:   zip
-- id:   websphere-liberty-runtime-jakartaee10
+- id:   websphere-liberty-runtime-jakartaee11
   purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
   with:
     uri:         https://repo1.maven.org/maven2
     group_id:    com.ibm.websphere.appserver.runtime
-    artifact_id: wlp-jakartaee10
+    artifact_id: wlp-jakartaee11
     packaging:   zip
-- id:   websphere-liberty-runtime-webProfile10
+- id:   websphere-liberty-runtime-webProfile11
   purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   cpe_pattern:     "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"
   uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
   with:
     uri:         https://repo1.maven.org/maven2
     group_id:    com.ibm.websphere.appserver.runtime
-    artifact_id: wlp-webProfile10
+    artifact_id: wlp-webProfile11
     packaging:   zip
 - id:   websphere-liberty-runtime-javaee8
   purl_pattern:    "[\\d]+\\.[\\d]+\\.[\\d]+\\.[\\d]+"

--- a/.github/workflows/pb-update-open-liberty-runtime-jakartaee-11.yml
+++ b/.github/workflows/pb-update-open-liberty-runtime-jakartaee-11.yml
@@ -1,4 +1,4 @@
-name: Update open-liberty-runtime-jakartaee10
+name: Update open-liberty-runtime-jakartaee11
 "on":
     schedule:
         - cron: 0 5 * * 1-5
@@ -27,7 +27,7 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
-                artifact_id: openliberty-jakartaee10
+                artifact_id: openliberty-jakartaee11
                 group_id: io.openliberty
                 packaging: zip
                 uri: https://repo1.maven.org/maven2
@@ -80,7 +80,7 @@ jobs:
                 ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
-                ID: open-liberty-runtime-jakartaee10
+                ID: open-liberty-runtime-jakartaee11
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
@@ -92,14 +92,14 @@ jobs:
             - uses: peter-evans/create-pull-request@v8
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
-                body: Bumps `open-liberty-runtime-jakartaee10` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                body: Bumps `open-liberty-runtime-jakartaee11` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
                 branch: update/buildpack/open-liberty-runtime-jakartaee-10
                 commit-message: |-
-                    Bump open-liberty-runtime-jakartaee10 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                    Bump open-liberty-runtime-jakartaee11 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
 
-                    Bumps open-liberty-runtime-jakartaee10 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                    Bumps open-liberty-runtime-jakartaee11 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
                 delete-branch: true
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
-                title: Bump open-liberty-runtime-jakartaee10 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                title: Bump open-liberty-runtime-jakartaee11 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-open-liberty-runtime-web-profile-11.yml
+++ b/.github/workflows/pb-update-open-liberty-runtime-web-profile-11.yml
@@ -1,4 +1,4 @@
-name: Update websphere-liberty-runtime-jakartaee10
+name: Update open-liberty-runtime-webProfile11
 "on":
     schedule:
         - cron: 0 5 * * 1-5
@@ -27,8 +27,8 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
-                artifact_id: wlp-jakartaee10
-                group_id: com.ibm.websphere.appserver.runtime
+                artifact_id: openliberty-webProfile11
+                group_id: io.openliberty
                 packaging: zip
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
@@ -80,7 +80,7 @@ jobs:
                 ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
-                ID: websphere-liberty-runtime-jakartaee10
+                ID: open-liberty-runtime-webProfile11
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
@@ -92,14 +92,14 @@ jobs:
             - uses: peter-evans/create-pull-request@v8
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
-                body: Bumps `websphere-liberty-runtime-jakartaee10` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
-                branch: update/buildpack/websphere-liberty-runtime-jakartaee-10
+                body: Bumps `open-liberty-runtime-webProfile11` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/open-liberty-runtime-web-profile-10
                 commit-message: |-
-                    Bump websphere-liberty-runtime-jakartaee10 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                    Bump open-liberty-runtime-webProfile11 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
 
-                    Bumps websphere-liberty-runtime-jakartaee10 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                    Bumps open-liberty-runtime-webProfile11 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
                 delete-branch: true
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
-                title: Bump websphere-liberty-runtime-jakartaee10 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                title: Bump open-liberty-runtime-webProfile11 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-websphere-liberty-runtime-jakartaee-11.yml
+++ b/.github/workflows/pb-update-websphere-liberty-runtime-jakartaee-11.yml
@@ -1,4 +1,4 @@
-name: Update websphere-liberty-runtime-webProfile10
+name: Update websphere-liberty-runtime-jakartaee11
 "on":
     schedule:
         - cron: 0 5 * * 1-5
@@ -27,7 +27,7 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
-                artifact_id: wlp-webProfile10
+                artifact_id: wlp-jakartaee11
                 group_id: com.ibm.websphere.appserver.runtime
                 packaging: zip
                 uri: https://repo1.maven.org/maven2
@@ -80,7 +80,7 @@ jobs:
                 ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
-                ID: websphere-liberty-runtime-webProfile10
+                ID: websphere-liberty-runtime-jakartaee11
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
@@ -92,14 +92,14 @@ jobs:
             - uses: peter-evans/create-pull-request@v8
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
-                body: Bumps `websphere-liberty-runtime-webProfile10` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
-                branch: update/buildpack/websphere-liberty-runtime-web-profile-10
+                body: Bumps `websphere-liberty-runtime-jakartaee11` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/websphere-liberty-runtime-jakartaee-10
                 commit-message: |-
-                    Bump websphere-liberty-runtime-webProfile10 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                    Bump websphere-liberty-runtime-jakartaee11 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
 
-                    Bumps websphere-liberty-runtime-webProfile10 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                    Bumps websphere-liberty-runtime-jakartaee11 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
                 delete-branch: true
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
-                title: Bump websphere-liberty-runtime-webProfile10 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                title: Bump websphere-liberty-runtime-jakartaee11 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/pb-update-websphere-liberty-runtime-web-profile-11.yml
+++ b/.github/workflows/pb-update-websphere-liberty-runtime-web-profile-11.yml
@@ -1,4 +1,4 @@
-name: Update open-liberty-runtime-webProfile10
+name: Update websphere-liberty-runtime-webProfile11
 "on":
     schedule:
         - cron: 0 5 * * 1-5
@@ -27,8 +27,8 @@ jobs:
             - id: dependency
               uses: docker://ghcr.io/paketo-buildpacks/actions/liberty-dependency:main
               with:
-                artifact_id: openliberty-webProfile10
-                group_id: io.openliberty
+                artifact_id: wlp-webProfile11
+                group_id: com.ibm.websphere.appserver.runtime
                 packaging: zip
                 uri: https://repo1.maven.org/maven2
             - name: Update Buildpack Dependency
@@ -80,7 +80,7 @@ jobs:
                 ARCH: ""
                 CPE: ${{ steps.dependency.outputs.cpe }}
                 CPE_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
-                ID: open-liberty-runtime-webProfile10
+                ID: websphere-liberty-runtime-webProfile11
                 PURL: ${{ steps.dependency.outputs.purl }}
                 PURL_PATTERN: '[\d]+\.[\d]+\.[\d]+\.[\d]+'
                 SHA256: ${{ steps.dependency.outputs.sha256 }}
@@ -92,14 +92,14 @@ jobs:
             - uses: peter-evans/create-pull-request@v8
               with:
                 author: ${{ secrets.JAVA_GITHUB_USERNAME }} <${{ secrets.JAVA_GITHUB_USERNAME }}@users.noreply.github.com>
-                body: Bumps `open-liberty-runtime-webProfile10` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
-                branch: update/buildpack/open-liberty-runtime-web-profile-10
+                body: Bumps `websphere-liberty-runtime-webProfile11` from `${{ steps.buildpack.outputs.old-version }}` to `${{ steps.buildpack.outputs.new-version }}`.
+                branch: update/buildpack/websphere-liberty-runtime-web-profile-10
                 commit-message: |-
-                    Bump open-liberty-runtime-webProfile10 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                    Bump websphere-liberty-runtime-webProfile11 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
 
-                    Bumps open-liberty-runtime-webProfile10 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
+                    Bumps websphere-liberty-runtime-webProfile11 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}.
                 delete-branch: true
                 labels: ${{ steps.buildpack.outputs.version-label }}, type:dependency-upgrade
                 signoff: true
-                title: Bump open-liberty-runtime-webProfile10 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
+                title: Bump websphere-liberty-runtime-webProfile11 from ${{ steps.buildpack.outputs.old-version }} to ${{ steps.buildpack.outputs.new-version }}
                 token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -61,20 +61,20 @@ Valid profiles for Open Liberty are:
 
 * full
 * kernel
-* jakartaee10
+* jakartaee11
 * javaee8
-* webProfile9
 * webProfile8
+* webProfile11
 * microProfile7
 * microProfile4
 
 Valid profiles for WebSphere Liberty are:
 
 * kernel
-* jakartaee10
+* jakartaee11
 * javaee8
 * javaee7
-* webProfile10
+* webProfile11
 * webProfile8
 * webProfile7
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -138,16 +138,16 @@ api = "0.7"
       uri = "https://raw.githubusercontent.com/OpenLiberty/open-liberty/integration/LICENSE"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:ibm:open_liberty:26.0.0.4:*:*:*:*:*:*:*"]
-    id = "open-liberty-runtime-jakartaee10"
-    name = "Open Liberty (Jakarta EE10)"
-    purl = "pkg:maven/io.openliberty/openliberty-jakartaee10@26.0.0.4"
-    sha256 = "3d9e22e689e451371b558956315fbe4dba8853f747d9daf593a0bd4759971404"
-    source = "https://github.com/OpenLiberty/open-liberty/archive/refs/tags/gm-26.0.0.4.tar.gz"
-    source-sha256 = "82c7ac171d7c9e17f55aaf7bd5fa375469693c1760647b4f4d6cea4a2d0e232b"
+    cpes = ["cpe:2.3:a:ibm:open_liberty:26.0.0.5:*:*:*:*:*:*:*"]
+    id = "open-liberty-runtime-jakartaee11"
+    name = "Open Liberty (Jakarta EE11)"
+    purl = "pkg:maven/io.openliberty/openliberty-jakartaee11@26.0.0.5"
+    sha256 = "4648a89b7b16297bfa70c0a666963695c59a55331cc94e96a1d47ed4cc63b110"
+    source = "https://github.com/OpenLiberty/open-liberty/archive/refs/tags/gm-26.0.0.5.tar.gz"
+    source-sha256 = "c3bcbadc2d71a6d6b131bb00fe9327a1ddb8a46a059fcb051349cd9017058352"
     stacks = ["*"]
-    uri = "https://repo1.maven.org/maven2/io/openliberty/openliberty-jakartaee10/26.0.0.4/openliberty-jakartaee10-26.0.0.4.zip"
-    version = "26.0.4"
+    uri = "https://repo1.maven.org/maven2/io/openliberty/openliberty-jakartaee11/26.0.0.5/openliberty-jakartaee11-26.0.0.5.zip"
+    version = "26.0.5"
 
     [[metadata.dependencies.licenses]]
       type = "EPL-2.0"
@@ -170,16 +170,16 @@ api = "0.7"
       uri = "https://raw.githubusercontent.com/OpenLiberty/open-liberty/integration/LICENSE"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:ibm:open_liberty:26.0.0.4:*:*:*:*:*:*:*"]
-    id = "open-liberty-runtime-webProfile10"
-    name = "Open Liberty (Web Profile 10)"
-    purl = "pkg:maven/io.openliberty/openliberty-webProfile10@26.0.0.4"
-    sha256 = "bec7df1a9c4b49e55375fba1d29b8df8e1f91a72c67591a64f9c9103839e8f43"
-    source = "https://github.com/OpenLiberty/open-liberty/archive/refs/tags/gm-26.0.0.4.tar.gz"
-    source-sha256 = "82c7ac171d7c9e17f55aaf7bd5fa375469693c1760647b4f4d6cea4a2d0e232b"
+    cpes = ["cpe:2.3:a:ibm:open_liberty:26.0.0.5:*:*:*:*:*:*:*"]
+    id = "open-liberty-runtime-webProfile11"
+    name = "Open Liberty (Web Profile 11)"
+    purl = "pkg:maven/io.openliberty/openliberty-webProfile11@26.0.0.5"
+    sha256 = "d672f9da2968878d29f950b481b22b353ee2d9d945a251a439a56c4c59056b7a"
+    source = "https://github.com/OpenLiberty/open-liberty/archive/refs/tags/gm-26.0.0.5.tar.gz"
+    source-sha256 = "c3bcbadc2d71a6d6b131bb00fe9327a1ddb8a46a059fcb051349cd9017058352"
     stacks = ["*"]
-    uri = "https://repo1.maven.org/maven2/io/openliberty/openliberty-webProfile10/26.0.0.4/openliberty-webProfile10-26.0.0.4.zip"
-    version = "26.0.4"
+    uri = "https://repo1.maven.org/maven2/io/openliberty/openliberty-webProfile11/26.0.0.5/openliberty-webProfile11-26.0.0.5.zip"
+    version = "26.0.5"
 
     [[metadata.dependencies.licenses]]
       type = "EPL-2.0"
@@ -264,14 +264,14 @@ api = "0.7"
       uri = "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/23.0.0.3/lafiles/runtime/en.html"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:ibm:websphere_application_server:26.0.0.4:*:*:*:liberty:*:*:*"]
-    id = "websphere-liberty-runtime-jakartaee10"
-    name = "WebSphere Liberty (Jakarta EE9)"
-    purl = "pkg:maven/com.ibm.websphere.appserver.runtime/wlp-jakartaee10@26.0.0.4"
-    sha256 = "fbe6ea7eb03683ee725990c37e28d1990206de5808209437903cbee939686ded"
+    cpes = ["cpe:2.3:a:ibm:websphere_application_server:26.0.0.5:*:*:*:liberty:*:*:*"]
+    id = "websphere-liberty-runtime-jakartaee11"
+    name = "WebSphere Liberty (Jakarta EE11)"
+    purl = "pkg:maven/com.ibm.websphere.appserver.runtime/wlp-jakartaee11@26.0.0.5"
+    sha256 = "d7479c5c76ccb811286721c40c18ce4573942b979b277e77805a27a50bc8f60a"
     stacks = ["*"]
-    uri = "https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-jakartaee10/26.0.0.4/wlp-jakartaee10-26.0.0.4.zip"
-    version = "26.0.4"
+    uri = "https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-jakartaee11/26.0.0.5/wlp-jakartaee11-26.0.0.5.zip"
+    version = "26.0.5"
 
     [[metadata.dependencies.licenses]]
       type = "Proprietary"
@@ -306,14 +306,14 @@ api = "0.7"
       uri = "https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/23.0.0.3/lafiles/runtime/en.html"
 
   [[metadata.dependencies]]
-    cpes = ["cpe:2.3:a:ibm:websphere_application_server:26.0.0.4:*:*:*:liberty:*:*:*"]
-    id = "websphere-liberty-runtime-webProfile10"
-    name = "WebSphere Liberty (Web Profile 10)"
-    purl = "pkg:maven/com.ibm.websphere.appserver.runtime/wlp-webProfile10@26.0.0.4"
-    sha256 = "75513ac857a4e0810415a454ee175f6a594e1842ff235c0096f7b34b4e03e104"
+    cpes = ["cpe:2.3:a:ibm:websphere_application_server:26.0.0.5:*:*:*:liberty:*:*:*"]
+    id = "websphere-liberty-runtime-webProfile11"
+    name = "WebSphere Liberty (Web Profile 11)"
+    purl = "pkg:maven/com.ibm.websphere.appserver.runtime/wlp-webProfile11@26.0.0.5"
+    sha256 = "285a59df4f5a8141879475a44814bb34e4a12eada84015bf0af6e6843353e3a5"
     stacks = ["*"]
-    uri = "https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-webProfile10/26.0.0.4/wlp-webProfile10-26.0.0.4.zip"
-    version = "26.0.4"
+    uri = "https://repo1.maven.org/maven2/com/ibm/websphere/appserver/runtime/wlp-webProfile11/26.0.0.5/wlp-webProfile11-26.0.0.5.zip"
+    version = "26.0.5"
 
     [[metadata.dependencies.licenses]]
       type = "Proprietary"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -104,9 +104,9 @@ func GetFeatureList(profile string, serverPath string, additionalFeatures []stri
 func IsValidOpenLibertyProfile(profile string) bool {
 	return profile == "full" ||
 		profile == "kernel" ||
-		profile == "jakartaee10" ||
+		profile == "jakartaee11" ||
 		profile == "javaee8" ||
-		profile == "webProfile10" ||
+		profile == "webProfile11" ||
 		profile == "webProfile8" ||
 		profile == "microProfile7" ||
 		profile == "microProfile4"
@@ -114,10 +114,10 @@ func IsValidOpenLibertyProfile(profile string) bool {
 
 func IsValidWebSphereLibertyProfile(profile string) bool {
 	return profile == "kernel" ||
-		profile == "jakartaee10" ||
+		profile == "jakartaee11" ||
 		profile == "javaee8" ||
 		profile == "javaee7" ||
-		profile == "webProfile10" ||
+		profile == "webProfile11" ||
 		profile == "webProfile8" ||
 		profile == "webProfile7"
 }

--- a/liberty/build_test.go
+++ b/liberty/build_test.go
@@ -65,7 +65,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			"dependencies": []map[string]interface{}{
 				{"id": "open-liberty-runtime-kernel", "version": "21.0.11"},
 				{"id": "websphere-liberty-runtime-kernel", "version": "21.0.11"},
-				{"id": "open-liberty-runtime-jakartaee10", "version": "21.0.11"},
+				{"id": "open-liberty-runtime-jakartaee11", "version": "21.0.11"},
 			},
 		}
 
@@ -146,8 +146,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			sbomScanner.AssertCalled(t, "ScanLaunch", ctx.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON)
 		})
 
-		it("selects the latest jakartaee10 profile for Open Liberty", func() {
-			Expect(os.Setenv("BP_LIBERTY_PROFILE", "jakartaee10")).To(Succeed())
+		it("selects the latest jakartaee11 profile for Open Liberty", func() {
+			Expect(os.Setenv("BP_LIBERTY_PROFILE", "jakartaee11")).To(Succeed())
 			result, err := liberty.Build{
 				Logger:      bard.NewLogger(io.Discard),
 				SBOMScanner: &sbomScanner,
@@ -158,7 +158,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(result.Layers).To(HaveLen(3))
 			Expect(result.Layers[0].Name()).To(Equal("helper"))
 			Expect(result.Layers[1].Name()).To(Equal("base"))
-			Expect(result.Layers[2].Name()).To(Equal("open-liberty-runtime-jakartaee10"))
+			Expect(result.Layers[2].Name()).To(Equal("open-liberty-runtime-jakartaee11"))
 
 			sbomScanner.AssertCalled(t, "ScanLaunch", ctx.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON)
 		})
@@ -263,7 +263,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 	context("user env config set", func() {
 		it.Before(func() {
 			Expect(os.Setenv("BP_LIBERTY_VERSION", "21.0.11")).To(Succeed())
-			Expect(os.Setenv("BP_LIBERTY_PROFILE", "jakartaee10")).To(Succeed())
+			Expect(os.Setenv("BP_LIBERTY_PROFILE", "jakartaee11")).To(Succeed())
 			Expect(os.MkdirAll(filepath.Join(ctx.Application.Path, "META-INF"), 0755)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(ctx.Application.Path, "META-INF", "application.xml"), []byte{}, 0644)).To(Succeed())
 		})
@@ -284,7 +284,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(result.Layers).To(HaveLen(3))
 			Expect(result.Layers[0].Name()).To(Equal("helper"))
 			Expect(result.Layers[1].Name()).To(Equal("base"))
-			Expect(result.Layers[2].Name()).To(Equal("open-liberty-runtime-jakartaee10"))
+			Expect(result.Layers[2].Name()).To(Equal("open-liberty-runtime-jakartaee11"))
 
 			sbomScanner.AssertCalled(t, "ScanLaunch", ctx.Application.Path, libcnb.SyftJSON, libcnb.CycloneDXJSON)
 		})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The 26.0.0.5 release of WebSphere and Open Liberty removed webProfile10 and jakartaee10 binary prereqs and replaced with webProfile11 and jakartaee11 binaries.  

## Use Cases
<!-- An explanation of the use cases your change enables -->
Liberty Buildpack uses wanting to use webProfile11 and JarkartaEE11 features would need this update. 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
